### PR TITLE
Fix the empty drawer bug on quick consecutive profile switches

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/accountswitcher/AccountHeader.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/accountswitcher/AccountHeader.java
@@ -714,7 +714,7 @@ public class AccountHeader {
             if (drawerItem != null && drawerItem instanceof IProfile && ((IProfile) drawerItem).isSelectable()) {
                 switchProfiles((IProfile) drawerItem);
             }
-
+            mDrawer.setOnDrawerItemClickListener(null);
             //wrap the onSelection call and the reset stuff within a handler to prevent lag
             new Handler().postDelayed(new Runnable() {
                 @Override


### PR DESCRIPTION
If you select a profile the drawer calls `onDrawerItemClickListener` in `AccountHeader.java`. This switches the profile as needed:
```Java
if (drawerItem != null && drawerItem instanceof IProfile && ((IProfile) drawerItem).isSelectable()) {
    switchProfiles((IProfile) drawerItem);
}
```
And starts the handler to do a smooth transition:
```Java
new Handler().postDelayed(new Runnable() {
    @Override
    public void run() {
        if (drawerItem != null && drawerItem instanceof IProfile) {
            mOnAccountHeaderClickListener.onSelectionClick((IProfile) drawerItem);
        }
        if (mDrawer != null) {
            resetDrawerContent(view.getContext());
        }

    }
}, 500);
```
The issue is in this handler. Once the handler is done it calls the following function:
```Java
private void resetDrawerContent(Context ctx) {
    mDrawer.setOnDrawerItemClickListener(originalOnDrawerItemClickListener);
    mDrawer.setItems(originalDrawerItems);
    mDrawer.setSelection(originalDrawerSelection, false);

    originalOnDrawerItemClickListener = null;
    originalDrawerItems = null;
    originalDrawerSelection = -1;

    mAccountSwitcherArrow.setImageDrawable(new IconicsDrawable(ctx, GoogleMaterial.Icon.gmd_arrow_drop_down).sizeDp(24).paddingDp(6).color(mTextColor));
}
```
If you select two profiles within 500 milliseconds the first `resetDrawerContent()` call sets the original click listener, items and selection to null or -1. So once the handler for the second profile click finishes it sets these null and -1 values as the parameters in the drawer.

My solution was to disable the drawer's `OnDrawerItemClickListener` by setting it to null. This prevents any further profile clicks, and considering the drawer is reset in all cases afterward, it should not have any negative effect. During the quick testing I did it seemed to have fixed the bug.