### PR TITLE
Use the right ActionBarDrawerToggle constructor 

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
@@ -630,43 +630,23 @@ public class Drawer {
 
         // create the ActionBarDrawerToggle if not set and enabled
         if (mActionBarDrawerToggleEnabled && mActionBarDrawerToggle == null) {
-            if (mToolbar == null) {
-                this.mActionBarDrawerToggle = new ActionBarDrawerToggle(mActivity, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
-                    @Override
-                    public void onDrawerOpened(View drawerView) {
-                        if (mOnDrawerListener != null) {
-                            mOnDrawerListener.onDrawerOpened(drawerView);
-                        }
-                        super.onDrawerOpened(drawerView);
+            this.mActionBarDrawerToggle = new ActionBarDrawerToggle(mActivity, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
+                @Override
+                public void onDrawerOpened(View drawerView) {
+                    if (mOnDrawerListener != null) {
+                        mOnDrawerListener.onDrawerOpened(drawerView);
                     }
+                    super.onDrawerOpened(drawerView);
+                }
 
-                    @Override
-                    public void onDrawerClosed(View drawerView) {
-                        if (mOnDrawerListener != null) {
-                            mOnDrawerListener.onDrawerClosed(drawerView);
-                        }
-                        super.onDrawerClosed(drawerView);
+                @Override
+                public void onDrawerClosed(View drawerView) {
+                    if (mOnDrawerListener != null) {
+                        mOnDrawerListener.onDrawerClosed(drawerView);
                     }
-                };
-            } else {
-                this.mActionBarDrawerToggle = new ActionBarDrawerToggle(mActivity, mDrawerLayout, mToolbar, R.string.drawer_open, R.string.drawer_close) {
-                    @Override
-                    public void onDrawerOpened(View drawerView) {
-                        if (mOnDrawerListener != null) {
-                            mOnDrawerListener.onDrawerOpened(drawerView);
-                        }
-                        super.onDrawerOpened(drawerView);
-                    }
-
-                    @Override
-                    public void onDrawerClosed(View drawerView) {
-                        if (mOnDrawerListener != null) {
-                            mOnDrawerListener.onDrawerClosed(drawerView);
-                        }
-                        super.onDrawerClosed(drawerView);
-                    }
-                };
-            }
+                    super.onDrawerClosed(drawerView);
+                }
+            };
             this.mActionBarDrawerToggle.syncState();
         }
 


### PR DESCRIPTION
Use the right ActionBarDrawerToggle constructor  when the activity has actionbar defined.

According to the documentation from
[reference](https://developer.android.com/reference/android/support/v7/app/ActionBarDrawerToggle.html#ActionBarDrawerToggle(android.app.Activity, android.support.v4.widget.DrawerLayout, android.support.v7.widget.Toolbar, int, int) )
The second constructor should NOT be used if you are setting the Toolbar as the ActionBar of your activity.
The use of this second constructor has the side effect that the "back button click" is not longer captured
by the onOptionsItemSelected() of the Activity.
Please take a look to http://stackoverflow.com/a/28177091/3744415