### PR TITLE
Added section divider to the navigation drawer.

### DIFF
--- a/app/src/main/java/com/mikepenz/materialdrawer/app/SimpleHeaderDrawerActivity.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/SimpleHeaderDrawerActivity.java
@@ -18,6 +18,7 @@ import com.mikepenz.materialdrawer.model.PrimaryDrawerItem;
 import com.mikepenz.materialdrawer.model.ProfileDrawerItem;
 import com.mikepenz.materialdrawer.model.ProfileSettingDrawerItem;
 import com.mikepenz.materialdrawer.model.SecondaryDrawerItem;
+import com.mikepenz.materialdrawer.model.SectionDividerDrawerItem;
 import com.mikepenz.materialdrawer.model.SectionDrawerItem;
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
 import com.mikepenz.materialdrawer.model.interfaces.IProfile;
@@ -91,6 +92,7 @@ public class SimpleHeaderDrawerActivity extends ActionBarActivity {
                         new SectionDrawerItem().withName(R.string.drawer_item_section_header),
                         new SecondaryDrawerItem().withName(R.string.drawer_item_settings).withIcon(FontAwesome.Icon.faw_cog).withIdentifier(5).withTextColor(Color.RED),
                         new SecondaryDrawerItem().withName(R.string.drawer_item_help).withIcon(FontAwesome.Icon.faw_question).setEnabled(false),
+                        new SectionDividerDrawerItem(), // simple divider without any texts
                         new SecondaryDrawerItem().withName(R.string.drawer_item_open_source).withIcon(FontAwesome.Icon.faw_github).withIdentifier(4).withCheckable(false),
                         new SecondaryDrawerItem().withName(R.string.drawer_item_contact).withIcon(GoogleMaterial.Icon.gmd_format_color_fill).withTag("Bullhorn")
                 ) // add the items we want to use with our Drawer

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/SectionDividerDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/SectionDividerDrawerItem.java
@@ -1,0 +1,78 @@
+package com.mikepenz.materialdrawer.model;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.mikepenz.materialdrawer.R;
+import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
+import com.mikepenz.materialdrawer.model.interfaces.Tagable;
+import com.mikepenz.materialdrawer.util.UIUtils;
+
+
+/**
+ * Created at 11.03.15 21:06
+ * @author RustamG
+ */
+public class SectionDividerDrawerItem
+        implements IDrawerItem, Tagable<SectionDividerDrawerItem> {
+
+    private Object tag;
+
+
+    public SectionDividerDrawerItem withTag(Object object) {
+
+        this.tag = object;
+        return this;
+    }
+
+
+    @Override
+    public Object getTag() {
+
+        return tag;
+    }
+
+    @Override
+    public void setTag(Object tag) {
+
+        this.tag = tag;
+    }
+
+    @Override
+    public int getIdentifier() {
+
+        return -1;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return false;
+    }
+
+    @Override
+    public String getType() {
+
+        return "SECTION_DIVIDER_ITEM";
+    }
+
+    @Override
+    public int getLayoutRes() {
+
+        return R.layout.material_drawer_divider_item_section;
+    }
+
+    @Override
+    public View convertView(LayoutInflater inflater, View convertView, ViewGroup parent) {
+
+        if (convertView == null) {
+            convertView = inflater.inflate(getLayoutRes(), parent, false);
+            convertView.setBackgroundColor(
+                    UIUtils.getThemeColorFromAttrOrRes(parent.getContext(), R.attr.material_drawer_divider,
+                            R.color.material_drawer_divider));
+        }
+
+        return convertView;
+    }
+}

--- a/library/src/main/res/layout/material_drawer_divider_item_section.xml
+++ b/library/src/main/res/layout/material_drawer_divider_item_section.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View
+    android:id="@+id/divider"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:layout_marginBottom="@dimen/material_drawer_padding"
+    android:layout_marginTop="@dimen/material_drawer_padding" />


### PR DESCRIPTION
I need to have a section divider in the navigation drawer without section header. So please, include my implementation.

The result looks like this: 

![Section divider](https://monosnap.com/file/SzjMqzTvPNoUNztt1pSmXSWgtGB1q2.png)