### PR TITLE
Kitkat changes

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
@@ -1192,6 +1192,12 @@ public class Drawer {
             UIUtils.setBackground(mSliderLayout, mSliderBackgroundColorRes);
         }
 
+        // kitkat already adds its own shadow, so hide the top shadow on this api level
+        if (Build.VERSION.SDK_INT == 19) {
+            View sliderLayoutShadowTop = mSliderLayout.findViewById(R.id.shadow_top);
+            sliderLayoutShadowTop.setBackgroundColor(Color.TRANSPARENT);
+        }
+
         //create the content
         createContent();
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
@@ -1010,7 +1010,12 @@ public class Drawer {
             if (mStatusBarColor == 0 && mStatusBarColorRes != -1) {
                 mStatusBarColor = mActivity.getResources().getColor(mStatusBarColorRes);
             } else if (mStatusBarColor == 0) {
-                mStatusBarColor = UIUtils.getThemeColorFromAttrOrRes(mActivity, R.attr.colorPrimaryDark, R.color.material_drawer_primary_dark);
+                if (Build.VERSION.SDK_INT == 19) {
+                    // don't use the dark color on kitkat, it conflicts with the native shadow
+                    mStatusBarColor = UIUtils.getThemeColorFromAttrOrRes(mActivity, R.attr.colorPrimary, R.color.material_drawer_primary);
+                }else{
+                    mStatusBarColor = UIUtils.getThemeColorFromAttrOrRes(mActivity, R.attr.colorPrimaryDark, R.color.material_drawer_primary_dark);
+                }
             }
             mDrawerContentRoot.setInsetForeground(mStatusBarColor);
         }


### PR DESCRIPTION
Hi,

I've made some changes on how the status bar is displayed on kitkat devices only, because kitkat already adds its own shadow and I think it conflicts with the shadows/colors this library adds.

I think the first commit is the most important (2366bbe), as there was no way for the user to change this via the API. It removes the shadow on the top of the slider on android devices. I thought this was especially ugly on lists without a header image.

Screenshot: Left is before, right is after change
![slider-statusbar-changes](https://cloud.githubusercontent.com/assets/3082124/7134876/734292a2-e2a1-11e4-9c52-0b6de3198064.png)

The second commit (e71661c) changes the status bar color on kitkat devices, it now uses the primary color instead of the primary dark color. This is less important, because the user could already change that color. This is how I did it in the past: `.withStatusBarColorRes((Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) ? R.color.primary : R.color.primaryDark)`

Screenshot: Left is before, right is after change
![slider-statusbar-changes-2](https://cloud.githubusercontent.com/assets/3082124/7134980/8aedb07a-e2a2-11e4-9432-aca1c965bbbb.png)
