### PR TITLE
ColorfulBadge

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/model/PrimaryDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/PrimaryDrawerItem.java
@@ -1,6 +1,7 @@
 package com.mikepenz.materialdrawer.model;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,18 +11,19 @@ import android.widget.TextView;
 
 import com.mikepenz.iconics.IconicsDrawable;
 import com.mikepenz.materialdrawer.R;
-import com.mikepenz.materialdrawer.model.interfaces.Badgeable;
+import com.mikepenz.materialdrawer.model.interfaces.ColorfulBadgeable;
 import com.mikepenz.materialdrawer.util.PressedEffectStateListDrawable;
 import com.mikepenz.materialdrawer.util.UIUtils;
 
 /**
  * Created by mikepenz on 03.02.15.
  */
-public class PrimaryDrawerItem extends BaseDrawerItem<PrimaryDrawerItem> implements Badgeable<PrimaryDrawerItem> {
+public class PrimaryDrawerItem extends BaseDrawerItem<PrimaryDrawerItem> implements ColorfulBadgeable<PrimaryDrawerItem> {
     private String description;
     private int descriptionRes = -1;
 
     private String badge;
+    private int badgeTextColor = 0;
 
     public PrimaryDrawerItem withDescription(String description) {
         this.description = description;
@@ -33,8 +35,15 @@ public class PrimaryDrawerItem extends BaseDrawerItem<PrimaryDrawerItem> impleme
         return this;
     }
 
+    @Override
     public PrimaryDrawerItem withBadge(String badge) {
         this.badge = badge;
+        return this;
+    }
+
+    @Override
+    public PrimaryDrawerItem withBadgeTextColor(int color) {
+        this.badgeTextColor = color;
         return this;
     }
 
@@ -57,6 +66,14 @@ public class PrimaryDrawerItem extends BaseDrawerItem<PrimaryDrawerItem> impleme
     public String getBadge() {
         return badge;
     }
+
+	@Override
+    public int getBadgeTextColor() {
+        return badgeTextColor;
+    }
+
+    @Override
+    public void setBadgeTextColor(int color) { this.badgeTextColor = color; }
 
     @Override
     public void setBadge(String badge) {
@@ -167,7 +184,9 @@ public class PrimaryDrawerItem extends BaseDrawerItem<PrimaryDrawerItem> impleme
 
         viewHolder.name.setTextColor(UIUtils.getTextColor(color, selected_text));
         viewHolder.description.setTextColor(UIUtils.getTextColor(color, selected_text));
-        viewHolder.badge.setTextColor(UIUtils.getTextColor(color, selected_text));
+	    if (badgeTextColor != 0) {
+		    viewHolder.badge.setTextColor(badgeTextColor);
+	    } else viewHolder.badge.setTextColor(UIUtils.getTextColor(color, selected_text));
 
         if (getTypeface() != null) {
             viewHolder.name.setTypeface(getTypeface());

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/SecondaryDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/SecondaryDrawerItem.java
@@ -11,15 +11,17 @@ import android.widget.TextView;
 import com.mikepenz.iconics.IconicsDrawable;
 import com.mikepenz.materialdrawer.R;
 import com.mikepenz.materialdrawer.model.interfaces.Badgeable;
+import com.mikepenz.materialdrawer.model.interfaces.ColorfulBadgeable;
 import com.mikepenz.materialdrawer.util.PressedEffectStateListDrawable;
 import com.mikepenz.materialdrawer.util.UIUtils;
 
 /**
  * Created by mikepenz on 03.02.15.
  */
-public class SecondaryDrawerItem extends BaseDrawerItem<SecondaryDrawerItem> implements Badgeable<SecondaryDrawerItem> {
+public class SecondaryDrawerItem extends BaseDrawerItem<SecondaryDrawerItem> implements ColorfulBadgeable<SecondaryDrawerItem> {
 
     private String badge;
+    private int badgeTextColor = 0;
 
     public SecondaryDrawerItem withBadge(String badge) {
         this.badge = badge;
@@ -34,6 +36,20 @@ public class SecondaryDrawerItem extends BaseDrawerItem<SecondaryDrawerItem> imp
     public void setBadge(String badge) {
         this.badge = badge;
     }
+
+    @Override
+    public SecondaryDrawerItem withBadgeTextColor(int color) {
+        this.badgeTextColor = color;
+        return this;
+    }
+
+    @Override
+    public int getBadgeTextColor() {
+        return badgeTextColor;
+    }
+
+    @Override
+    public void setBadgeTextColor(int color) { this.badgeTextColor = color; }
 
     @Override
     public String getType() {
@@ -128,7 +144,9 @@ public class SecondaryDrawerItem extends BaseDrawerItem<SecondaryDrawerItem> imp
         }
 
         viewHolder.name.setTextColor(UIUtils.getTextColor(color, selected_text));
-        viewHolder.badge.setTextColor(UIUtils.getTextColor(color, selected_text));
+        if (badgeTextColor != 0) {
+            viewHolder.badge.setTextColor(badgeTextColor);
+        } else viewHolder.badge.setTextColor(UIUtils.getTextColor(color, selected_text));
 
         if (getTypeface() != null) {
             viewHolder.name.setTypeface(getTypeface());

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/ColorfulBadgeable.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/ColorfulBadgeable.java
@@ -1,0 +1,12 @@
+package com.mikepenz.materialdrawer.model.interfaces;
+
+/**
+ * Created by mikepenz on 03.02.15.
+ */
+public interface ColorfulBadgeable<T> extends Badgeable<T> {
+    public T withBadgeTextColor(int color);
+
+    public int getBadgeTextColor();
+
+    public void setBadgeTextColor(int color);
+}


### PR DESCRIPTION
fix #229 

For the background stuff I don't know what to do, since there is a need to have 3 options:Color, Drawable and resource.

About material design compatibility, it is not enabled by default and it for rare use cases.
I need it for PRO badge near some drawer items.
