### PR TITLE
Update BezelImageView.java

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/view/BezelImageView.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/view/BezelImageView.java
@@ -319,7 +319,7 @@ public class BezelImageView extends ImageView {
 
     @Override
     public void setImageURI(Uri uri) {
-        if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
+        if ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme())) {
             DrawerImageLoader.getInstance().setImage(this, uri);
         } else {
             super.setImageURI(uri);


### PR DESCRIPTION
Changed ordering of String.equals() statements in line 322.

This is to avoid NullPointerExceptions when supplying the AccountHeader with invalid Icon URLs.

Currently the app crashes when using for example an empty String. The app should instead go through to the placeholder without a crash.