### PR TITLE
Fixed deselection of all items and added withSelectedItem by identifier

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/DrawerBuilder.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/DrawerBuilder.java
@@ -769,6 +769,20 @@ public class DrawerBuilder {
         return this;
     }
 
+    // item to select
+    protected int mSelectedItemIdentifier = 0;
+
+    /**
+     * Set this to the identifier of the item, you would love to select upon start
+     *
+     * @param selectedItemIdentifier
+     * @return
+     */
+    public DrawerBuilder withSelectedItem(int selectedItemIdentifier) {
+        this.mSelectedItemIdentifier = selectedItemIdentifier;
+        return this;
+    }
+
     // an RecyclerView to use within the drawer :D
     protected RecyclerView mRecyclerView;
 
@@ -1464,6 +1478,9 @@ public class DrawerBuilder {
         }
 
         //predefine selection (should be the first element
+        if(mSelectedItemPosition == 0 && mSelectedItemIdentifier != 0) {
+            mSelectedItemPosition = DrawerUtils.getPositionByIdentifier(this, mSelectedItemIdentifier);
+        }
         if (mHeaderView != null && mSelectedItemPosition == 0) {
             mSelectedItemPosition = 1;
         }

--- a/library/src/main/java/com/mikepenz/materialdrawer/DrawerUtils.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/DrawerUtils.java
@@ -96,7 +96,7 @@ class DrawerUtils {
     public static boolean setRecyclerViewSelection(DrawerBuilder drawer, int position, boolean fireOnClick, IDrawerItem drawerItem) {
         if (position >= -1) {
             //predefine selection (should be the first element
-            if (drawer.mAdapter != null && (position) > -1) {
+            if (drawer.mAdapter != null) {
                 drawer.resetStickyFooterSelection();
                 drawer.mAdapter.handleSelection(null, position);
                 drawer.mCurrentSelection = position;


### PR DESCRIPTION
In the old situation, when position = -1, nothing would ever happen.
The check for position > -1 is already in place in the `handleSelect` function, so no need to do that here as well.