### PR TITLE
added: convenience getter/setter methods for OnDrawerNavigationListener

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/Drawer.java
@@ -895,6 +895,21 @@ public class Drawer {
         return mDrawerBuilder.mOnDrawerItemLongClickListener;
     }
 
+    /**
+     * Sets the {@link OnDrawerNavigationListener}.
+     * @param onDrawerNavigationListener the OnDrawerNavigationListener
+     */
+    public void setOnDrawerNavigationListener(OnDrawerNavigationListener onDrawerNavigationListener) {
+        mDrawerBuilder.mOnDrawerNavigationListener = onDrawerNavigationListener;
+    }
+
+    /**
+     * Gets the {@link OnDrawerNavigationListener}.
+     * @return the OnDrawerNavigationListener
+     */
+    public OnDrawerNavigationListener getOnDrawerNavigationListener() {
+        return mDrawerBuilder.mOnDrawerNavigationListener;
+    }
 
     //variables to store and remember the original list of the drawer
     private Drawer.OnDrawerItemClickListener originalOnDrawerItemClickListener;


### PR DESCRIPTION
Convenience methods added to get/set mDrawerBuilder.mOnDrawerNavigationListener.
Useful if you only have a Drawer object and want to change the behavior of the back arrow at any time/place in your application.