### PR TITLE
Make ViewHolder class public for PrimaryDrawerItem

### DIFF
--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlPrimaryDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlPrimaryDrawerItem.java
@@ -99,7 +99,7 @@ public class CustomUrlPrimaryDrawerItem extends CustomUrlBasePrimaryDrawerItem<C
         }
     }
 
-    static class ViewHolder extends CustomBaseViewHolder {
+    public static class ViewHolder extends CustomBaseViewHolder {
         private View badgeContainer;
         private TextView badge;
 

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/IconDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/IconDrawerItem.java
@@ -201,7 +201,7 @@ public class IconDrawerItem extends AbstractDrawerItem<IconDrawerItem, IconDrawe
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private View view;
         protected ImageView icon;
 

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/OverflowMenuDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/OverflowMenuDrawerItem.java
@@ -103,7 +103,7 @@ public class OverflowMenuDrawerItem extends BasePrimaryDrawerItem<OverflowMenuDr
         }
     }
 
-    static class ViewHolder extends BaseViewHolder {
+    public static class ViewHolder extends BaseViewHolder {
         //protected ImageButton ibOverflow;
         private ImageButton menu;
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ContainerDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ContainerDrawerItem.java
@@ -118,7 +118,7 @@ public class ContainerDrawerItem extends AbstractDrawerItem<ContainerDrawerItem,
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private View view;
 
         private ViewHolder(View view) {

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/DividerDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/DividerDrawerItem.java
@@ -57,7 +57,7 @@ public class DividerDrawerItem extends AbstractDrawerItem<DividerDrawerItem, Div
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private View view;
         private View divider;
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ExpandableDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ExpandableDrawerItem.java
@@ -110,7 +110,7 @@ public class ExpandableDrawerItem extends BasePrimaryDrawerItem<ExpandableDrawer
         }
     }
 
-    protected static class ViewHolder extends BaseViewHolder {
+    public static class ViewHolder extends BaseViewHolder {
         public IconicsImageView arrow;
 
         public ViewHolder(View view) {

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/MiniDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/MiniDrawerItem.java
@@ -176,7 +176,7 @@ public class MiniDrawerItem extends BaseDrawerItem<MiniDrawerItem, MiniDrawerIte
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private View view;
         private ImageView icon;
         private TextView badge;

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/MiniProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/MiniProfileDrawerItem.java
@@ -158,7 +158,7 @@ public class MiniProfileDrawerItem extends AbstractDrawerItem<MiniProfileDrawerI
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private ImageView icon;
 
         public ViewHolder(View view) {

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/PrimaryDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/PrimaryDrawerItem.java
@@ -98,7 +98,7 @@ public class PrimaryDrawerItem extends BasePrimaryDrawerItem<PrimaryDrawerItem, 
         }
     }
 
-    protected static class ViewHolder extends BaseViewHolder {
+    public static class ViewHolder extends BaseViewHolder {
         private View badgeContainer;
         private TextView badge;
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
@@ -259,7 +259,7 @@ public class ProfileDrawerItem extends AbstractDrawerItem<ProfileDrawerItem, Pro
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private View view;
         private ImageView profileIcon;
         private TextView name;

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -245,7 +245,7 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private View view;
         private ImageView icon;
         private TextView name;

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/SectionDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/SectionDrawerItem.java
@@ -148,7 +148,7 @@ public class SectionDrawerItem extends AbstractDrawerItem<SectionDrawerItem, Sec
         }
     }
 
-    protected static class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private View view;
         private View divider;
         private TextView name;

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/SwitchDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/SwitchDrawerItem.java
@@ -102,7 +102,7 @@ public class SwitchDrawerItem extends BasePrimaryDrawerItem<SwitchDrawerItem, Sw
         }
     }
 
-    protected static class ViewHolder extends BaseViewHolder {
+    public static class ViewHolder extends BaseViewHolder {
         private SwitchCompat switchView;
 
         private ViewHolder(View view) {

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ToggleDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ToggleDrawerItem.java
@@ -109,7 +109,7 @@ public class ToggleDrawerItem extends BasePrimaryDrawerItem<ToggleDrawerItem, To
         }
     }
 
-    protected static class ViewHolder extends BaseViewHolder {
+    public static class ViewHolder extends BaseViewHolder {
         private ToggleButton toggle;
 
         private ViewHolder(View view) {


### PR DESCRIPTION
Needed public because of Kotlin.

_PrimaryDrawerItem.ViewHolder is protected. And the bindView() method, which is public, accepts PrimaryDrawerItem.ViewHolder. But a general external caller cannot invoke this method because it cannot refer a protected nested class PrimaryDrawerItem.ViewHolder. Kotlin prohibits such behavior and requires either to make the parameter visibility equal to the method visibility or to decrease the parameter visibility to be less or equal to the method visibility._


Check
http://stackoverflow.com/questions/36722336/parameter-effective-visibility-conflict-between-java-and-kotlin/36724062#36724062