### PR TITLE
Make cleaner dependency management

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,88 +1,88 @@
 apply plugin: 'com.android.application'
 //wrap with try and catch so the build is working even if the signing stuff is missing
 try {
-    apply from: '../../../signing.gradle'
+  apply from: '../../../signing.gradle'
 } catch (ex) {
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+  compileSdkVersion setup.compileSdk
+  buildToolsVersion setup.buildTools
 
-    defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 23
-        versionCode 520
-        versionName "5.2.0"
+  defaultConfig {
+    minSdkVersion setup.minSdk
+    targetSdkVersion setup.targetSdk
+    versionCode 520
+    versionName "5.2.0"
 
-        applicationVariants.all { variant ->
-            variant.outputs.each { output ->
-                def file = output.outputFile
-                def fileName = file.name.replace(".apk", "-v" + versionName + "-c" + versionCode + ".apk")
-                output.outputFile = new File(file.parentFile, fileName)
-            }
-        }
+    applicationVariants.all { variant ->
+      variant.outputs.each { output ->
+        def file = output.outputFile
+        def fileName = file.name.replace(".apk", "-v" + versionName + "-c" + versionCode + ".apk")
+        output.outputFile = new File(file.parentFile, fileName)
+      }
     }
-    buildTypes {
-        debug {
-            applicationIdSuffix ".debug"
-            versionNameSuffix "-DEBUG"
-            try {
-                signingConfig signingConfigs.debug
-            } catch (ex) {
-            }
-            minifyEnabled false
-        }
-        release {
-            try {
-                signingConfig signingConfigs.release
-            } catch (ex) {
-            }
-            zipAlignEnabled true
-            minifyEnabled false
-        }
+  }
+  buildTypes {
+    debug {
+      applicationIdSuffix ".debug"
+      versionNameSuffix "-DEBUG"
+      try {
+        signingConfig signingConfigs.debug
+      } catch (ex) {
+      }
+      minifyEnabled false
     }
-    lintOptions {
-        abortOnError false
+    release {
+      try {
+        signingConfig signingConfigs.release
+      } catch (ex) {
+      }
+      zipAlignEnabled true
+      minifyEnabled false
     }
+  }
+  lintOptions {
+    abortOnError false
+  }
 }
 
 dependencies {
-    compile project(':library')
+  compile project(':library')
 
-    compile "com.android.support:design:${rootProject.ext.supportLibVersion}"
-    compile "com.android.support:cardview-v7:${rootProject.ext.supportLibVersion}"
+  compile "com.android.support:design:${versions.supportLib}"
+  compile "com.android.support:cardview-v7:${versions.supportLib}"
 
-    // used to showcase how to load images
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+  // used to showcase how to load images
+  compile 'com.squareup.picasso:picasso:2.5.2'
+  compile 'com.github.bumptech.glide:glide:3.7.0'
 
-    // used to generate the Open Source section
-    // https://github.com/mikepenz/AboutLibraries
-    compile('com.mikepenz:aboutlibraries:5.6.3@aar') {
-        transitive = true
-        exclude module: "fastadapter"
-    }
-    //used to provide different itemAnimators for the RecyclerView
-    //https://github.com/mikepenz/ItemAnimators
-    compile 'com.mikepenz:itemanimators:0.2.4@aar'
-    // used to provide the MiniDrawer to normal Drawer crossfade effect via a SlidingPane layout
-    // --> https://github.com/mikepenz/MaterialDrawer/blob/develop/app/src/main/java/com/mikepenz/materialdrawer/app/MiniDrawerActivity.java
-    // https://github.com/mikepenz/Crossfader
-    compile 'com.mikepenz:crossfader:1.3.7@aar'
-    // used to provide the two step crossfade DrawerLayout. Which allows to have a mini layout which transforms to a normal layout within the drawer
-    // --> https://github.com/mikepenz/MaterialDrawer/blob/develop/app/src/main/java/com/mikepenz/materialdrawer/app/CrossfadeDrawerLayoutActvitiy.java
-    // https://github.com/mikepenz/CrossfadeDrawerLayout
-    compile('com.mikepenz:crossfadedrawerlayout:0.3.4@aar')
+  // used to generate the Open Source section
+  // https://github.com/mikepenz/AboutLibraries
+  compile('com.mikepenz:aboutlibraries:5.6.3@aar') {
+    transitive = true
+    exclude module: "fastadapter"
+  }
+  //used to provide different itemAnimators for the RecyclerView
+  //https://github.com/mikepenz/ItemAnimators
+  compile 'com.mikepenz:itemanimators:0.2.4@aar'
+  // used to provide the MiniDrawer to normal Drawer crossfade effect via a SlidingPane layout
+  // --> https://github.com/mikepenz/MaterialDrawer/blob/develop/app/src/main/java/com/mikepenz/materialdrawer/app/MiniDrawerActivity.java
+  // https://github.com/mikepenz/Crossfader
+  compile 'com.mikepenz:crossfader:1.3.7@aar'
+  // used to provide the two step crossfade DrawerLayout. Which allows to have a mini layout which transforms to a normal layout within the drawer
+  // --> https://github.com/mikepenz/MaterialDrawer/blob/develop/app/src/main/java/com/mikepenz/materialdrawer/app/CrossfadeDrawerLayoutActvitiy.java
+  // https://github.com/mikepenz/CrossfadeDrawerLayout
+  compile('com.mikepenz:crossfadedrawerlayout:0.3.4@aar')
 
-    // icon fonts used inside the sample
-    // https://github.com/mikepenz/Android-Iconics
-    compile 'com.mikepenz:google-material-typeface:2.2.0.1@aar'
-    compile 'com.mikepenz:fontawesome-typeface:4.4.0.1@aar'
-    compile 'com.mikepenz:octicons-typeface:3.0.0.1@aar'
+  // icon fonts used inside the sample
+  // https://github.com/mikepenz/Android-Iconics
+  compile 'com.mikepenz:google-material-typeface:2.2.0.1@aar'
+  compile 'com.mikepenz:fontawesome-typeface:4.4.0.1@aar'
+  compile 'com.mikepenz:octicons-typeface:3.0.0.1@aar'
 
 
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
+  debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
+  releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
+  testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,31 @@
 buildscript {
-    repositories {
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
-        classpath 'com.novoda:bintray-release:0.3.4'
-    }
+  ext {
+    setup = [compileSdk: 23,
+             buildTools: "23.0.3",
+             minSdk    : 10,
+             targetSdk : 23]
+
+    versions = [supportLib: "23.3.0"]
+  }
+
+  repositories {
+    jcenter()
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.android.tools.build:gradle:2.0.0'
+    classpath 'com.novoda:bintray-release:0.3.4'
+  }
 }
 
 allprojects {
-    repositories {
-        jcenter()
-        mavenCentral()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-    }
-}
-
-ext {
-    compileSdkVersion = 23
-    buildToolsVersion = "23.0.3"
-    supportLibVersion = "23.3.0"
+  repositories {
+    jcenter()
+    mavenCentral()
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+  }
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.12'
+  gradleVersion = '2.12'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdkVersion setup.compileSdk
+    buildToolsVersion setup.buildTools
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 23
+        minSdkVersion setup.minSdk
+        targetSdkVersion setup.targetSdk
         versionCode 520
         versionName '5.2.0'
     }
@@ -28,10 +28,10 @@ apply from: 'gradle-mvn-push.gradle'
 apply from: 'gradle-jcenter-push.gradle'
 
 dependencies {
-    compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    compile "com.android.support:recyclerview-v7:${rootProject.ext.supportLibVersion}"
-    compile "com.android.support:support-annotations:${rootProject.ext.supportLibVersion}"
-    compile "com.android.support:design:${rootProject.ext.supportLibVersion}"
+    compile "com.android.support:appcompat-v7:${versions.supportLib}"
+    compile "com.android.support:recyclerview-v7:${versions.supportLib}"
+    compile "com.android.support:support-annotations:${versions.supportLib}"
+    compile "com.android.support:design:${versions.supportLib}"
 
     // used to base on some backwards compatible themes
     // contains util classes to support various android versions, and clean up code


### PR DESCRIPTION
Make it easy to use dependencies in gradle with just setup.variable or version.variable instead of rootProject.ext.variable.