### PR TITLE
Small fix so mIncludeSecondaryDrawerItems works in MiniDrawer

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/MiniDrawer.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/MiniDrawer.java
@@ -238,10 +238,10 @@ public class MiniDrawer {
      * @return
      */
     public IDrawerItem generateMiniDrawerItem(IDrawerItem drawerItem) {
-        if (drawerItem instanceof PrimaryDrawerItem) {
+        if (drawerItem instanceof SecondaryDrawerItem) {
+            return mIncludeSecondaryDrawerItems ? new MiniDrawerItem((SecondaryDrawerItem) drawerItem).withEnableSelectedBackground(mEnableSelectedMiniDrawerItemBackground) : null;
+        } else if (drawerItem instanceof PrimaryDrawerItem) {
             return new MiniDrawerItem((PrimaryDrawerItem) drawerItem).withEnableSelectedBackground(mEnableSelectedMiniDrawerItemBackground);
-        } else if (drawerItem instanceof SecondaryDrawerItem && mIncludeSecondaryDrawerItems) {
-            return new MiniDrawerItem((SecondaryDrawerItem) drawerItem).withEnableSelectedBackground(mEnableSelectedMiniDrawerItemBackground);
         } else if (drawerItem instanceof ProfileDrawerItem) {
             MiniProfileDrawerItem mpdi = new MiniProfileDrawerItem((ProfileDrawerItem) drawerItem);
             mpdi.withEnabled(mEnableProfileClick);


### PR DESCRIPTION
When i update from 5.1.1 to 5.2.1, SecondaryDrawerItem is showing in MiniDrawer.
After tracing since SecondaryDrawerItem is now subclass of PrimaryDrawerItem, then the condition in generateMiniDrawerItem does not work as expected.