### PR TITLE
Add javadoc to provide details about ProfileDrawerItem.withNameShown(..)

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
@@ -95,6 +95,12 @@ public class ProfileDrawerItem extends AbstractDrawerItem<ProfileDrawerItem, Pro
         return this;
     }
 
+  /**
+   * Whether to show the profile name in the account switcher.
+   *
+   * @param nameShown show name in switcher
+   * @return the {@link ProfileDrawerItem}
+   */
     public ProfileDrawerItem withNameShown(boolean nameShown) {
         this.nameShown = nameShown;
         return this;


### PR DESCRIPTION
As discussed in https://github.com/mikepenz/MaterialDrawer/issues/1570 this PR adds some javadoc documentation for the `ProfileDrawerItem.withNameShown` configuration.