### PR TITLE
Use `open()` method instead of `openDrawer()`

### DIFF
--- a/FAQ/opening-drawer-from-espresso.md
+++ b/FAQ/opening-drawer-from-espresso.md
@@ -7,4 +7,4 @@ First, you need a add `espresso-contrib` to your project. It has the needed `Dra
 
 Then, you need to open the drawer with his `openDrawer()` method and the drawer layout ID. The generated one is `R.id.material_drawer_layout`
 
-`DrawerActions.open(R.id.material_drawer_layout);`
+`onView(withId(R.id.material_drawer_layout)).perform(DrawerActions.open(Gravity.START));`

--- a/FAQ/opening-drawer-from-espresso.md
+++ b/FAQ/opening-drawer-from-espresso.md
@@ -7,4 +7,4 @@ First, you need a add `espresso-contrib` to your project. It has the needed `Dra
 
 Then, you need to open the drawer with his `openDrawer()` method and the drawer layout ID. The generated one is `R.id.material_drawer_layout`
 
-`DrawerActions.openDrawer(R.id.material_drawer_layout);`
+`DrawerActions.open(R.id.material_drawer_layout);`

--- a/FAQ/opening-drawer-from-espresso.md
+++ b/FAQ/opening-drawer-from-espresso.md
@@ -7,4 +7,4 @@ First, you need a add `espresso-contrib` to your project. It has the needed `Dra
 
 Then, you need to open the drawer with his `openDrawer()` method and the drawer layout ID. The generated one is `R.id.material_drawer_layout`
 
-`onView(withId(R.id.material_drawer_layout)).perform(DrawerActions.open(Gravity.START));`
+`onView(withId(R.id.material_drawer_layout)).perform(DrawerActions.open());`


### PR DESCRIPTION
Use `open()` method instead of `openDrawer()` because this method will be removed in the next release.