### PR TITLE
Set itemView tag in bindView for all DrawerItem classes

### DIFF
--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/AccountDividerDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/AccountDividerDrawerItem.java
@@ -35,6 +35,8 @@ public class AccountDividerDrawerItem extends AbstractDrawerItem<AccountDividerD
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //set the identifier from the drawerItem here. It can be used to run tests

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlBasePrimaryDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlBasePrimaryDrawerItem.java
@@ -74,9 +74,6 @@ public abstract class CustomUrlBasePrimaryDrawerItem<T, VH extends RecyclerView.
         //set the item selected if it is
         viewHolder.itemView.setSelected(isSelected());
 
-        //
-        viewHolder.itemView.setTag(this);
-
         //get the correct color for the background
         int selectedColor = getSelectedColor(ctx);
         //get the correct color for the text

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlPrimaryDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlPrimaryDrawerItem.java
@@ -66,6 +66,8 @@ public class CustomUrlPrimaryDrawerItem extends CustomUrlBasePrimaryDrawerItem<C
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //bind the basic view parts

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/IconDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/IconDrawerItem.java
@@ -169,6 +169,8 @@ public class IconDrawerItem extends AbstractDrawerItem<IconDrawerItem, IconDrawe
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //set the identifier from the drawerItem here. It can be used to run tests

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/OverflowMenuDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/OverflowMenuDrawerItem.java
@@ -67,6 +67,8 @@ public class OverflowMenuDrawerItem extends BaseDescribeableDrawerItem<OverflowM
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //bind the basic view parts

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractBadgeableDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractBadgeableDrawerItem.java
@@ -66,6 +66,8 @@ public abstract class AbstractBadgeableDrawerItem<Item extends AbstractBadgeable
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
         //bind the basic view parts
         bindViewHelper(viewHolder);

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.java
@@ -1,6 +1,7 @@
 package com.mikepenz.materialdrawer.model;
 
 import android.content.Context;
+import android.support.annotation.CallSuper;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -310,6 +311,12 @@ public abstract class AbstractDrawerItem<T, VH extends RecyclerView.ViewHolder> 
         VH viewHolder = getFactory().create(LayoutInflater.from(ctx).inflate(getLayoutRes(), parent, false));
         bindView(viewHolder, Collections.emptyList());
         return viewHolder.itemView;
+    }
+
+    @CallSuper
+    @Override
+    public void bindView(VH holder, List<Object> payloads) {
+        holder.itemView.setTag(this);
     }
 
     /**

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractSwitchableDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractSwitchableDrawerItem.java
@@ -67,6 +67,8 @@ public abstract class AbstractSwitchableDrawerItem<Item extends AbstractSwitchab
 
     @Override
     public void bindView(final ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         //bind the basic view parts
         bindViewHelper(viewHolder);
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractToggleableDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractToggleableDrawerItem.java
@@ -74,6 +74,8 @@ public class AbstractToggleableDrawerItem<Item extends AbstractToggleableDrawerI
 
     @Override
     public void bindView(final ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         //bind the basic view parts
         bindViewHelper(viewHolder);
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/BaseDescribeableDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/BaseDescribeableDrawerItem.java
@@ -65,9 +65,6 @@ public abstract class BaseDescribeableDrawerItem<T, VH extends BaseViewHolder> e
         //set the item enabled if it is
         viewHolder.itemView.setEnabled(isEnabled());
 
-        //
-        viewHolder.itemView.setTag(this);
-
         //get the correct color for the background
         int selectedColor = getSelectedColor(ctx);
         //get the correct color for the text

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ContainerDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ContainerDrawerItem.java
@@ -78,6 +78,8 @@ public class ContainerDrawerItem extends AbstractDrawerItem<ContainerDrawerItem,
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //set the identifier from the drawerItem here. It can be used to run tests

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/DividerDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/DividerDrawerItem.java
@@ -29,6 +29,8 @@ public class DividerDrawerItem extends AbstractDrawerItem<DividerDrawerItem, Div
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //set the identifier from the drawerItem here. It can be used to run tests

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ExpandableBadgeDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ExpandableBadgeDrawerItem.java
@@ -47,6 +47,8 @@ public class ExpandableBadgeDrawerItem extends BaseDescribeableDrawerItem<Expand
   }
 
   @Override public void bindView(ExpandableBadgeDrawerItem.ViewHolder viewHolder, List payloads) {
+    super.bindView(viewHolder, payloads);
+
     Context ctx = viewHolder.itemView.getContext();
     //bind the basic view parts
     bindViewHelper(viewHolder);

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ExpandableDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ExpandableDrawerItem.java
@@ -97,6 +97,8 @@ public class ExpandableDrawerItem extends BaseDescribeableDrawerItem<ExpandableD
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
         //bind the basic view parts
         bindViewHelper(viewHolder);

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/MiniDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/MiniDrawerItem.java
@@ -116,6 +116,8 @@ public class MiniDrawerItem extends BaseDrawerItem<MiniDrawerItem, MiniDrawerIte
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //set a different height for this item

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/MiniProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/MiniProfileDrawerItem.java
@@ -132,6 +132,8 @@ public class MiniProfileDrawerItem extends AbstractDrawerItem<MiniProfileDrawerI
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         if (customHeight != null) {
             RecyclerView.LayoutParams lp = (RecyclerView.LayoutParams) viewHolder.itemView.getLayoutParams();
             lp.height = customHeight.asPixel(viewHolder.itemView.getContext());

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
@@ -202,6 +202,8 @@ public class ProfileDrawerItem extends AbstractDrawerItem<ProfileDrawerItem, Pro
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //set the identifier from the drawerItem here. It can be used to run tests

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -209,6 +209,8 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         //get the context
         Context ctx = viewHolder.itemView.getContext();
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/SectionDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/SectionDrawerItem.java
@@ -105,6 +105,8 @@ public class SectionDrawerItem extends AbstractDrawerItem<SectionDrawerItem, Sec
 
     @Override
     public void bindView(ViewHolder viewHolder, List payloads) {
+        super.bindView(viewHolder, payloads);
+
         Context ctx = viewHolder.itemView.getContext();
 
         //set the identifier from the drawerItem here. It can be used to run tests


### PR DESCRIPTION
FastAdapter shows this warning otherwise:
```
The bindView method of this item should set the `Tag` on it's itemView (https://github.com/mikepenz/FastAdapter/blob/develop/library-core/src/main/java/com/mikepenz/fastadapter/items/AbstractItem.java#L189)
```