### PR TITLE
Add withSelectedBackgroundAnimated

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/DrawerUtils.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/DrawerUtils.java
@@ -398,7 +398,7 @@ class DrawerUtils {
             view.setTag(drawerItem);
 
             if (drawerItem.isEnabled()) {
-                //UIUtils.setBackground(view, UIUtils.getSelectableBackground(container.getContext(), selected_color, true));
+                //UIUtils.setBackground(view, UIUtils.getSelectableBackground(container.getContext(), selected_color, drawerItem.isSelectedBackgroundAnimated()));
                 view.setOnClickListener(onClickListener);
             }
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.java
@@ -138,6 +138,29 @@ public abstract class AbstractDrawerItem<T, VH extends RecyclerView.ViewHolder> 
         return mSelectable;
     }
 
+    // defines if the item's background' change should be animated when it is (de)selected
+    protected boolean mSelectedBackgroundAnimated = true;
+
+    /**
+     * set if this item is selectable
+     *
+     * @param selectedBackgroundAnimated true if this item's background should fade when it is (de) selected
+     * @return
+     */
+    @Override
+    public T withSelectedBackgroundAnimated(boolean selectedBackgroundAnimated) {
+        this.mSelectedBackgroundAnimated = selectedBackgroundAnimated;
+        return (T) this;
+    }
+
+    /**
+     * @return if this item is selectable
+     */
+    @Override
+    public boolean isSelectedBackgroundAnimated() {
+        return mSelectedBackgroundAnimated;
+    }
+
     public Drawer.OnDrawerItemClickListener mOnDrawerItemClickListener = null;
 
     public Drawer.OnDrawerItemClickListener getOnDrawerItemClickListener() {

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/BaseDescribeableDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/BaseDescribeableDrawerItem.java
@@ -75,7 +75,7 @@ public abstract class BaseDescribeableDrawerItem<T, VH extends BaseViewHolder> e
         int selectedIconColor = getSelectedIconColor(ctx);
 
         //set the background for the item
-        UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, true));
+        UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, isSelectedBackgroundAnimated()));
         //set the text for the name
         StringHolder.applyTo(this.getName(), viewHolder.name);
         //set the text for the description or hide

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/MiniDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/MiniDrawerItem.java
@@ -147,7 +147,7 @@ public class MiniDrawerItem extends BaseDrawerItem<MiniDrawerItem, MiniDrawerIte
             //get the correct color for the background
             int selectedColor = getSelectedColor(ctx);
             //set the background for the item
-            UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, true));
+            UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, isSelectedBackgroundAnimated()));
         }
 
         //set the text for the badge or hide

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
@@ -221,7 +221,7 @@ public class ProfileDrawerItem extends AbstractDrawerItem<ProfileDrawerItem, Pro
         int color = getColor(ctx);
         int selectedTextColor = getSelectedTextColor(ctx);
 
-        UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, true));
+        UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, isSelectedBackgroundAnimated()));
 
         if (nameShown) {
             viewHolder.name.setVisibility(View.VISIBLE);

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -229,7 +229,7 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
         int color = ColorHolder.color(getTextColor(), ctx, R.attr.material_drawer_primary_text, R.color.material_drawer_primary_text);
         int iconColor = ColorHolder.color(getIconColor(), ctx, R.attr.material_drawer_primary_icon, R.color.material_drawer_primary_icon);
 
-        UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, true));
+        UIUtils.setBackground(viewHolder.view, UIUtils.getSelectableBackground(ctx, selectedColor, isSelectedBackgroundAnimated()));
 
         StringHolder.applyTo(this.getName(), viewHolder.name);
         viewHolder.name.setTextColor(color);

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/IDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/IDrawerItem.java
@@ -28,6 +28,10 @@ public interface IDrawerItem<T, VH extends RecyclerView.ViewHolder> extends IIte
 
     T withSelectable(boolean selectable);
 
+    boolean isSelectedBackgroundAnimated();
+
+    T withSelectedBackgroundAnimated(boolean selectedBackgroundAnimated);
+
     int getType();
 
     int getLayoutRes();


### PR DESCRIPTION
This adds an option to disable a drawer item's background animation when it gets (de)selected.

**This pull request depends on this one: https://github.com/mikepenz/Materialize/pull/14**