### PR TITLE
Use AppCompatResources to properly support vector drawables

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/AccountHeaderBuilder.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/AccountHeaderBuilder.java
@@ -14,7 +14,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.v4.view.ViewCompat;
-import android.support.v7.widget.AppCompatDrawableManager;
+import android.support.v7.content.res.AppCompatResources;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
@@ -726,7 +726,7 @@ public class AccountHeaderBuilder {
     private void handleSelectionView(IProfile profile, boolean on) {
         if (on) {
             if (Build.VERSION.SDK_INT >= 21) {
-                ((FrameLayout) mAccountHeaderContainer).setForeground(AppCompatDrawableManager.get().getDrawable(mAccountHeaderContainer.getContext(), mAccountHeaderTextSectionBackgroundResource));
+                ((FrameLayout) mAccountHeaderContainer).setForeground(AppCompatResources.getDrawable(mAccountHeaderContainer.getContext(), mAccountHeaderTextSectionBackgroundResource));
                 mAccountHeaderContainer.setOnClickListener(onSelectionClickListener);
                 mAccountHeaderContainer.setTag(R.id.material_drawer_profile_header, profile);
             } else {

--- a/library/src/main/java/com/mikepenz/materialdrawer/AccountHeaderBuilder.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/AccountHeaderBuilder.java
@@ -13,8 +13,8 @@ import android.support.annotation.DimenRes;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.AppCompatDrawableManager;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
@@ -726,7 +726,7 @@ public class AccountHeaderBuilder {
     private void handleSelectionView(IProfile profile, boolean on) {
         if (on) {
             if (Build.VERSION.SDK_INT >= 21) {
-                ((FrameLayout) mAccountHeaderContainer).setForeground(ContextCompat.getDrawable(mAccountHeaderContainer.getContext(), mAccountHeaderTextSectionBackgroundResource));
+                ((FrameLayout) mAccountHeaderContainer).setForeground(AppCompatDrawableManager.get().getDrawable(mAccountHeaderContainer.getContext(), mAccountHeaderTextSectionBackgroundResource));
                 mAccountHeaderContainer.setOnClickListener(onSelectionClickListener);
                 mAccountHeaderContainer.setTag(R.id.material_drawer_profile_header, profile);
             } else {

--- a/library/src/main/java/com/mikepenz/materialdrawer/holder/ImageHolder.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/holder/ImageHolder.java
@@ -6,7 +6,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.support.annotation.DrawableRes;
-import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.AppCompatDrawableManager;
 import android.view.View;
 import android.widget.ImageView;
 
@@ -100,7 +100,7 @@ public class ImageHolder extends com.mikepenz.materialize.holder.ImageHolder {
         if (mIIcon != null) {
             icon = new IconicsDrawable(ctx, mIIcon).color(iconColor).sizeDp(24).paddingDp(paddingDp);
         } else if (getIconRes() != -1) {
-            icon = ContextCompat.getDrawable(ctx, getIconRes());
+            icon = AppCompatDrawableManager.get().getDrawable(ctx, getIconRes());
         } else if (getUri() != null) {
             try {
                 InputStream inputStream = ctx.getContentResolver().openInputStream(getUri());

--- a/library/src/main/java/com/mikepenz/materialdrawer/holder/ImageHolder.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/holder/ImageHolder.java
@@ -6,7 +6,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.support.annotation.DrawableRes;
-import android.support.v7.widget.AppCompatDrawableManager;
+import android.support.v7.content.res.AppCompatResources;
 import android.view.View;
 import android.widget.ImageView;
 
@@ -100,7 +100,7 @@ public class ImageHolder extends com.mikepenz.materialize.holder.ImageHolder {
         if (mIIcon != null) {
             icon = new IconicsDrawable(ctx, mIIcon).color(iconColor).sizeDp(24).paddingDp(paddingDp);
         } else if (getIconRes() != -1) {
-            icon = AppCompatDrawableManager.get().getDrawable(ctx, getIconRes());
+            icon = AppCompatResources.getDrawable(ctx, getIconRes());
         } else if (getUri() != null) {
             try {
                 InputStream inputStream = ctx.getContentResolver().openInputStream(getUri());

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/utils/BadgeDrawableBuilder.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/utils/BadgeDrawableBuilder.java
@@ -3,7 +3,7 @@ package com.mikepenz.materialdrawer.model.utils;
 import android.content.Context;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.StateListDrawable;
-import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.AppCompatDrawableManager;
 import android.util.StateSet;
 
 import com.mikepenz.materialdrawer.holder.BadgeStyle;
@@ -21,7 +21,7 @@ public class BadgeDrawableBuilder {
 
     public StateListDrawable build(Context ctx) {
         StateListDrawable stateListDrawable = new StateListDrawable();
-        GradientDrawable normal = (GradientDrawable) ContextCompat.getDrawable(ctx, mStyle.getGradientDrawable());
+        GradientDrawable normal = (GradientDrawable) AppCompatDrawableManager.get().getDrawable(ctx, mStyle.getGradientDrawable());
         GradientDrawable selected = (GradientDrawable) normal.getConstantState().newDrawable().mutate();
 
         ColorHolder.applyToOrTransparent(mStyle.getColor(), ctx, normal);

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/utils/BadgeDrawableBuilder.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/utils/BadgeDrawableBuilder.java
@@ -3,7 +3,7 @@ package com.mikepenz.materialdrawer.model.utils;
 import android.content.Context;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.StateListDrawable;
-import android.support.v7.widget.AppCompatDrawableManager;
+import android.support.v7.content.res.AppCompatResources;
 import android.util.StateSet;
 
 import com.mikepenz.materialdrawer.holder.BadgeStyle;
@@ -21,7 +21,7 @@ public class BadgeDrawableBuilder {
 
     public StateListDrawable build(Context ctx) {
         StateListDrawable stateListDrawable = new StateListDrawable();
-        GradientDrawable normal = (GradientDrawable) AppCompatDrawableManager.get().getDrawable(ctx, mStyle.getGradientDrawable());
+        GradientDrawable normal = (GradientDrawable) AppCompatResources.getDrawable(ctx, mStyle.getGradientDrawable());
         GradientDrawable selected = (GradientDrawable) normal.getConstantState().newDrawable().mutate();
 
         ColorHolder.applyToOrTransparent(mStyle.getColor(), ctx, normal);


### PR DESCRIPTION
In order to properly support the usage of vector drawables below API 21 is necessary to use AppCompatResources instead of ContextCompat to properly inflate drawable resources  defined as svg.
This is required in case of setting vectorDrawables.useSupportLibrary = true in your build.gradle, in order to support vectors through the use of srcCompat attribute in ImageViews.

Currently, trying to do this while using the MaterialDrawer library will make the app crash on devices using API lower than version 21. 