### PR TITLE
Make description item viewable in Profile setting

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -246,7 +246,7 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
         StringHolder.applyTo(this.getName(), viewHolder.name);
         viewHolder.name.setTextColor(color);
 
-        StringHolder.applyTo(this.getDescription(), viewHolder.description);
+        StringHolder.applyToOrHide(this.getDescription(), viewHolder.description);
         viewHolder.description.setTextColor(color);
 
         if (getTypeface() != null) {

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -36,12 +36,14 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
 
     private StringHolder name;
     private StringHolder email;
+    private StringHolder description;
 
     private boolean iconTinted = false;
 
     private ColorHolder selectedColor;
     private ColorHolder textColor;
     private ColorHolder iconColor;
+    private ColorHolder descriptionColor;
 
     private Typeface typeface = null;
 
@@ -89,7 +91,7 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
     }
 
     public ProfileSettingDrawerItem withDescription(String description) {
-        this.email = new StringHolder(description);
+        this.description = new StringHolder(description);
         return this;
     }
 
@@ -115,6 +117,16 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
     }
 
     public ProfileSettingDrawerItem withTextColorRes(@ColorRes int textColorRes) {
+        this.textColor = ColorHolder.fromColorRes(textColorRes);
+        return this;
+    }
+
+    public ProfileSettingDrawerItem withDescriptionTextColor(@ColorInt int textColor) {
+        this.textColor = ColorHolder.fromColor(textColor);
+        return this;
+    }
+
+    public ProfileSettingDrawerItem withDescriptionTextColorRes(@ColorRes int textColorRes) {
         this.textColor = ColorHolder.fromColorRes(textColorRes);
         return this;
     }
@@ -179,11 +191,11 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
     }
 
     public StringHolder getDescription() {
-        return email;
+        return description;
     }
 
     public void setDescription(String description) {
-        this.email = new StringHolder(description);
+        this.description = new StringHolder(description);
     }
 
     @Override
@@ -234,6 +246,9 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
         StringHolder.applyTo(this.getName(), viewHolder.name);
         viewHolder.name.setTextColor(color);
 
+        StringHolder.applyTo(this.getDescription(), viewHolder.description);
+        viewHolder.description.setTextColor(color);
+
         if (getTypeface() != null) {
             viewHolder.name.setTypeface(getTypeface());
         }
@@ -263,12 +278,14 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
         private View view;
         private ImageView icon;
         private TextView name;
+        private TextView description;
 
         private ViewHolder(View view) {
             super(view);
             this.view = view;
             this.icon = (ImageView) view.findViewById(R.id.material_drawer_icon);
             this.name = (TextView) view.findViewById(R.id.material_drawer_name);
+            this.description = (TextView) view.findViewById(R.id.material_drawer_description);
         }
     }
 }

--- a/library/src/main/res/layout/material_drawer_item_profile_setting.xml
+++ b/library/src/main/res/layout/material_drawer_item_profile_setting.xml
@@ -21,14 +21,36 @@
         android:paddingStart="0dp"
         android:paddingTop="@dimen/material_drawer_item_profile_setting_icon_padding" />
 
-    <TextView
-        android:id="@+id/material_drawer_name"
-        android:layout_width="match_parent"
+    <LinearLayout
+        android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:fontFamily="sans-serif"
+        android:layout_weight="1"
         android:gravity="center_vertical|start"
-        android:lines="1"
-        android:singleLine="true"
-        android:textSize="@dimen/material_drawer_item_profile_text"
-        tools:text="Some drawer text" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/material_drawer_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center_vertical|start"
+            android:lines="1"
+            android:maxLines="1"
+            android:textDirection="anyRtl"
+            android:textSize="@dimen/material_drawer_item_primary_text"
+            tools:text="Some drawer text" />
+
+        <TextView
+            android:id="@+id/material_drawer_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif"
+            android:gravity="center_vertical|start"
+            android:lines="1"
+            android:maxLines="1"
+            android:textDirection="anyRtl"
+            android:textSize="@dimen/material_drawer_item_primary_description"
+            tools:text="Some drawer text" />
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
In the current version, Profile Setting has an option of adding a description, but it does not add the description. These commits fix the description in Profile Setting Drawer item. 