### PR TITLE
Added more options for consistency and convenience

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/holder/BadgeStyle.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/holder/BadgeStyle.java
@@ -5,6 +5,7 @@ import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
+import android.support.annotation.DimenRes;
 import android.support.annotation.DrawableRes;
 import android.widget.TextView;
 
@@ -92,13 +93,23 @@ public class BadgeStyle {
         return mCorners;
     }
 
-    public BadgeStyle withCorners(int corners) {
-        this.mCorners = DimenHolder.fromPixel(corners);
+    public BadgeStyle withCorners(int cornersPx) {
+        this.mCorners = DimenHolder.fromPixel(cornersPx);
         return this;
     }
 
-    public BadgeStyle withCornersDp(int corners) {
-        this.mCorners = DimenHolder.fromDp(corners);
+    public BadgeStyle withCornersPx(int cornersPx) {
+        this.mCorners = DimenHolder.fromPixel(cornersPx);
+        return this;
+    }
+
+    public BadgeStyle withCornersDp(int cornersDp) {
+        this.mCorners = DimenHolder.fromDp(cornersDp);
+        return this;
+    }
+
+    public BadgeStyle withCornersRes(@DimenRes int cornersRes) {
+        this.mCorners = DimenHolder.fromResource(cornersRes);
         return this;
     }
 
@@ -116,6 +127,11 @@ public class BadgeStyle {
         return this;
     }
 
+    public BadgeStyle withPaddingLeftRightRees(@DimenRes int paddingLeftRight) {
+        this.mPaddingLeftRight = DimenHolder.fromResource(paddingLeftRight);
+        return this;
+    }
+
     public DimenHolder getPaddingTopBottom() {
         return mPaddingTopBottom;
     }
@@ -130,9 +146,32 @@ public class BadgeStyle {
         return this;
     }
 
-    public BadgeStyle withPadding(int padding) {
+    public BadgeStyle withPaddingTopBottomRes(@DimenRes int paddingTopBottom) {
+        this.mPaddingTopBottom = DimenHolder.fromResource(paddingTopBottom);
+        return this;
+    }
+
+    public BadgeStyle withPadding(int paddingPx) {
+        this.mPaddingLeftRight = DimenHolder.fromPixel(paddingPx);
+        this.mPaddingTopBottom = DimenHolder.fromPixel(paddingPx);
+        return this;
+    }
+
+    public BadgeStyle withPaddingPx(int padding) {
         this.mPaddingLeftRight = DimenHolder.fromPixel(padding);
         this.mPaddingTopBottom = DimenHolder.fromPixel(padding);
+        return this;
+    }
+
+    public BadgeStyle withPaddingDp(int padding) {
+        this.mPaddingLeftRight = DimenHolder.fromDp(padding);
+        this.mPaddingTopBottom = DimenHolder.fromDp(padding);
+        return this;
+    }
+
+    public BadgeStyle withPaddingRes(@DimenRes int padding) {
+        this.mPaddingLeftRight = DimenHolder.fromResource(padding);
+        this.mPaddingTopBottom = DimenHolder.fromResource(padding);
         return this;
     }
 
@@ -140,8 +179,23 @@ public class BadgeStyle {
         return mMinWidth;
     }
 
-    public BadgeStyle withMinWidth(int minWidth) {
-        this.mMinWidth = DimenHolder.fromPixel(minWidth);
+    public BadgeStyle withMinWidth(int minWidthPx) {
+        this.mMinWidth = DimenHolder.fromPixel(minWidthPx);
+        return this;
+    }
+
+    public BadgeStyle withMinWidthPx(int minWidthPx) {
+        this.mMinWidth = DimenHolder.fromPixel(minWidthPx);
+        return this;
+    }
+
+    public BadgeStyle withMinWidthDp(int minWidthPx) {
+        this.mMinWidth = DimenHolder.fromDp(minWidthPx);
+        return this;
+    }
+
+    public BadgeStyle withMinWidthRes(@DimenRes int minWidthPx) {
+        this.mMinWidth = DimenHolder.fromResource(minWidthPx);
         return this;
     }
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
@@ -6,10 +6,7 @@ import android.graphics.Bitmap;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.support.annotation.ColorInt;
-import android.support.annotation.ColorRes;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.LayoutRes;
+import android.support.annotation.*;
 import android.support.v7.widget.RecyclerView;
 import android.util.Pair;
 import android.view.View;
@@ -89,8 +86,18 @@ public class ProfileDrawerItem extends AbstractDrawerItem<ProfileDrawerItem, Pro
         return this;
     }
 
+    public ProfileDrawerItem withName(@StringRes int nameRes) {
+        this.name = new StringHolder(nameRes);
+        return this;
+    }
+
     public ProfileDrawerItem withEmail(String email) {
         this.email = new StringHolder(email);
+        return this;
+    }
+
+    public ProfileDrawerItem withEmail(@StringRes int emailRes) {
+        this.email = new StringHolder(emailRes);
         return this;
     }
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -5,10 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.support.annotation.ColorInt;
-import android.support.annotation.ColorRes;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.LayoutRes;
+import android.support.annotation.*;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
@@ -88,8 +85,18 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
         return this;
     }
 
+    public ProfileSettingDrawerItem withName(@StringRes int nameRes) {
+        this.name = new StringHolder(nameRes);
+        return this;
+    }
+
     public ProfileSettingDrawerItem withDescription(String description) {
         this.description = new StringHolder(description);
+        return this;
+    }
+
+    public ProfileSettingDrawerItem withDescription(@StringRes int descriptionRes) {
+        this.description = new StringHolder(descriptionRes);
         return this;
     }
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -34,7 +34,6 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
     private ImageHolder icon;
 
     private StringHolder name;
-    private StringHolder email;
     private StringHolder description;
 
     private boolean iconTinted = false;
@@ -96,7 +95,7 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
 
     //NOTE we reuse the IProfile here to allow custom items within the AccountSwitcher. There is an alias method withDescription for this
     public ProfileSettingDrawerItem withEmail(String email) {
-        this.email = new StringHolder(email);
+        this.description = new StringHolder(email);
         return this;
     }
 
@@ -190,7 +189,7 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
     }
 
     public StringHolder getEmail() {
-        return email;
+        return description;
     }
 
     public StringHolder getDescription() {


### PR DESCRIPTION
2c12ea8c2e1c681ebf7b912d3c5454f4b05eccf2 fixes a bug where the `withEmail` function had no effect, the value passed to it is never shown on the UI. This was a preparation step for one of the following commits.

The others add new methods for setting various things which are trivial to implement, and improve API consistency while providing users with more options:

- 795b498e22bff4318d870b612dd62678b5dc0b1c adds the ability to use String resources when setting the name and description of `ProfileDrawerItem`s and `ProfileSettingDrawerItem`s, this kind of option is already present in other places, like in `BaseDrawerItem`.
- 7a8d5c64dfe132dedc05a57138da3fa1ab1fbc59 adds methods so that setting various dimensions in `BadgeStyle` can be done by all possible formats that a `DimenHolder` can be created from: pixels, dps, or dimension resources. This is just a lot more convenient than forcing users to do conversions to use the few methods that were available to set these fields.