### PR TITLE
Optimization to material_drawer_header.xml

### DIFF
--- a/library/src/main/res/layout/material_drawer_header.xml
+++ b/library/src/main/res/layout/material_drawer_header.xml
@@ -7,7 +7,7 @@
         android:id="@+id/material_drawer_account_header_background"
         android:layout_width="match_parent"
         android:layout_height="@dimen/material_drawer_account_header_height"
-        android:scaleType="fitXY" />
+        android:scaleType="centerCrop" />
 
     <RelativeLayout
         android:id="@+id/material_drawer_account_header"


### PR DESCRIPTION
I have set drawer_header.png as source to my project and I got an ugly stretched image. I can crop my image to fit the same aspect ratio of the header but I think it should be better to set the scaleType to centerCrop so every image looks good. I appreciate your work. Thank you for this library