### PR TITLE
Correct support library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         ]
 
         versions = [
-                supportLib: "26.0.0"
+                supportLib: "26.0.0-alpha1"
         ]
     }
 


### PR DESCRIPTION
`com.android.support:appcompat-v7:26.0.0` does not exist as a gradle dependency. Though `com.android.support:appcompat-v7:26.0.0-alpha1` does and it is the correct support suffix for now.

Google's been rearranging these things for quite a while, but at the time I'm writing this the following version works: `26.0.0-alpha1`