### PR TITLE
Removed redundant dependencies

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,9 +28,6 @@ apply from: 'gradle-mvn-push.gradle'
 apply from: 'gradle-jcenter-push.gradle'
 
 dependencies {
-    compile "com.android.support:appcompat-v7:${versions.supportLib}"
-    compile "com.android.support:recyclerview-v7:${versions.supportLib}"
-    compile "com.android.support:support-annotations:${versions.supportLib}"
     compile "com.android.support:design:${versions.supportLib}"
 
     // used to base on some backwards compatible themes


### PR DESCRIPTION
appcompat-v7, recyclerview-v7 and support-annotations are being imported by com.android.support:design and there is no need to have them explicitly

```
com.android.support:design:26.0.0
    +--- com.android.support:multidex:1.0.1
    +--- com.android.support:support-v4:26.0.0 (*)
    +--- com.android.support:appcompat-v7:26.0.0 (*)
    +--- com.android.support:recyclerview-v7:26.0.0 (*)
    \--- com.android.support:transition:26.0.0
         +--- com.android.support:support-annotations:26.0.0
         \--- com.android.support:support-v4:26.0.0 (*)
```


With the current setup if application that imports MaterialDrawer uses app-compat libraries, different from those in the library, the following setup is required in build.gradle:

```gradle
compile('com.mikepenz:materialdrawer:5.9.5@aar') {
        transitive = true
        exclude module: 'appcompat-v7'
        exclude module: 'recyclerview'
        exclude module: 'support-annotations'
        exclude module: 'design'
}
compile "com.android.support:design:$newSupportLibVersion"
```
With this change, gradle setup becomes a bit simpler:
```gradle
compile('com.mikepenz:materialdrawer:5.9.5@aar') {
        transitive = true
        exclude module: 'design'
}
compile "com.android.support:design:$newSupportLibVersion"
```