### PR TITLE
KeyboardUtil OnGlobalLayoutListener discriminates against nav bar hiding

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/util/KeyboardUtil.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/util/KeyboardUtil.java
@@ -69,7 +69,7 @@ public class KeyboardUtil {
             int diff = height - r.bottom;
 
             //if it could be a keyboard add the padding to the view
-            if (diff != 0) {
+            if (diff > 0) {
                 // if the use-able screen height differs from the total screen height we assume that it shows a keyboard now
                 //check if the padding is 0 (if yes set the padding for the keyboard)
                 if (contentView.getPaddingBottom() != diff) {


### PR DESCRIPTION
Some devices like the S8+ allow the user to hide the navigation bar, and this currently triggers some funky behavior where negative padding is set on `contentView`

On this S8+, I see `View#getWindowVisibleDisplayFrame()` returning a value larger than `getDisplayMetrics().heightPixels`. It seems like Samsung doesn't count the pixels that makeup the navigation bar in its DisplayMetrics even though they become available when hiding the nav bar 🤦‍♂️ .