### PR TITLE
Use Canvas.ALL_SAVE_FLAG when calling Canvas.saveLayer

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/view/BezelImageView.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/view/BezelImageView.java
@@ -210,8 +210,7 @@ public class BezelImageView extends ImageView {
                 } else {
                     mMaskedPaint.setColorFilter(null);
                 }
-                cacheCanvas.saveLayer(mBoundsF, mMaskedPaint,
-                        Canvas.HAS_ALPHA_LAYER_SAVE_FLAG | Canvas.FULL_COLOR_LAYER_SAVE_FLAG);
+                cacheCanvas.saveLayer(mBoundsF, mMaskedPaint, Canvas.ALL_SAVE_FLAG);
                 super.onDraw(cacheCanvas);
                 cacheCanvas.restoreToCount(sc);
             } else if (isSelected) {
@@ -222,8 +221,7 @@ public class BezelImageView extends ImageView {
                 } else {
                     mMaskedPaint.setColorFilter(mDesaturateColorFilter);
                 }
-                cacheCanvas.saveLayer(mBoundsF, mMaskedPaint,
-                        Canvas.HAS_ALPHA_LAYER_SAVE_FLAG | Canvas.FULL_COLOR_LAYER_SAVE_FLAG);
+                cacheCanvas.saveLayer(mBoundsF, mMaskedPaint, Canvas.ALL_SAVE_FLAG);
                 super.onDraw(cacheCanvas);
                 cacheCanvas.restoreToCount(sc);
             } else {


### PR DESCRIPTION
The current documentation of [android.graphics.Canvas](https://developer.android.com/reference/android/graphics/Canvas.html) only lists [`Canvas.ALL_SAVE_FLAG`](https://developer.android.com/reference/android/graphics/Canvas.html#ALL_SAVE_FLAG) as a constant. And according to the [API diff for level 26](https://developer.android.com/sdk/api_diff/26/changes/android.graphics.Canvas), all other `_SAVE_FLAG` constants were deprecated in API 26.

This would not otherwise be an issue, but since the release of Android P, the above documentation has recently added:

> As of API Level `Build.VERSION_CODES.P` the only valid `saveFlags` is `ALL_SAVE_FLAG`. All other flags are ignored.

However, the last sentence is not strictly true, because, on Android P, using any other constant actually causes the app to crash with:

> ```
> E/UncaughtException: java.lang.IllegalArgumentException: Invalid Layer Save Flag - only ALL_SAVE_FLAGS is allowed
>         at android.graphics.Canvas.checkValidSaveFlags(Canvas.java:378)
>         at android.graphics.Canvas.saveLayer(Canvas.java:455)
>         at com.mikepenz.materialdrawer.view.BezelImageView.onDraw(BezelImageView.java:213)
>         [...]
> ```

The recommended usage is to pass `Canvas.ALL_SAVE_FLAG` only, or use the new [`int saveLayer (RectF bounds, Paint paint)`](https://developer.android.com/reference/android/graphics/Canvas.html#savelayer_42) method introduced in API 21.

I understand that Android P is currently in Developer Preview, but thought I'd get this in early so you have a chance to test and investigate this further.

Finally, I've not contributed to your (great) project before, so I hope this PR is acceptable.