### PR TITLE
allow the use of CharSequence for profile names

### DIFF
--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/AccountDividerDrawerItem.java
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/AccountDividerDrawerItem.java
@@ -57,7 +57,7 @@ public class AccountDividerDrawerItem extends AbstractDrawerItem<AccountDividerD
 
 
     @Override
-    public AccountDividerDrawerItem withName(String name) {
+    public AccountDividerDrawerItem withName(CharSequence name) {
         return null;
     }
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/MiniProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/MiniProfileDrawerItem.java
@@ -38,7 +38,7 @@ public class MiniProfileDrawerItem extends AbstractDrawerItem<MiniProfileDrawerI
     }
 
     @Override
-    public MiniProfileDrawerItem withName(String name) {
+    public MiniProfileDrawerItem withName(CharSequence name) {
         return null;
     }
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.java
@@ -81,7 +81,7 @@ public class ProfileDrawerItem extends AbstractDrawerItem<ProfileDrawerItem, Pro
         return this;
     }
 
-    public ProfileDrawerItem withName(String name) {
+    public ProfileDrawerItem withName(CharSequence name) {
         this.name = new StringHolder(name);
         return this;
     }

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.java
@@ -80,7 +80,7 @@ public class ProfileSettingDrawerItem extends AbstractDrawerItem<ProfileSettingD
         return this;
     }
 
-    public ProfileSettingDrawerItem withName(String name) {
+    public ProfileSettingDrawerItem withName(CharSequence name) {
         this.name = new StringHolder(name);
         return this;
     }

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/IProfile.java
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/IProfile.java
@@ -14,7 +14,7 @@ import com.mikepenz.materialdrawer.holder.StringHolder;
  * Created by mikepenz on 03.02.15.
  */
 public interface IProfile<T> extends IIdentifyable<T> {
-    T withName(String name);
+    T withName(CharSequence name);
 
     StringHolder getName();
 


### PR DESCRIPTION
In [Tusky](https://github.com/tuskyapp/Tusky) we would like to use EmojiCompat for emojis in profile names. With this change we can simply do `EmojiCompat.process()`