### PR TITLE
Added Jetpack Navigation Compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply plugin: "androidx.navigation.safeargs.kotlin"
+
 //wrap with try and catch so the build is working even if the signing stuff is missing
 try {
     apply from: '../../../signing.gradle'
@@ -68,6 +70,8 @@ dependencies {
     // used to showcase how to load images
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'com.github.bumptech.glide:glide:4.9.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     kapt 'com.github.bumptech.glide:compiler:4.9.0'
 
     // needed to fix glide androidX support
@@ -101,6 +105,10 @@ dependencies {
 
     // kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+
+    // navigation
+    implementation "androidx.navigation:navigation-fragment-ktx:${versions.navigation}"
+    implementation "androidx.navigation:navigation-ui-ktx:${versions.navigation}"
 }
 
 configurations.all {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.mikepenz.materialdrawer.app">
@@ -18,6 +19,7 @@
             android:theme="@style/MaterialDrawerTheme.Light.DarkToolbar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -65,6 +67,11 @@
         <activity
             android:name=".CrossfadeDrawerLayoutActvitiy"
             android:theme="@style/MaterialDrawerTheme.TranslucentStatus" />
+        <activity
+            android:name=".NavControllerActivity"
+            android:label="NavControllerExample"
+            android:theme="@style/MaterialDrawerTheme.Light.DarkToolbar">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/DrawerActivity.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/DrawerActivity.kt
@@ -115,6 +115,7 @@ class DrawerActivity : AppCompatActivity() {
                                 SecondaryDrawerItem().withName("CollapsableItem").withLevel(2).withIcon(GoogleMaterial.Icon.gmd_filter_list).withIdentifier(2002),
                                 SecondaryDrawerItem().withName("CollapsableItem 2").withLevel(2).withIcon(GoogleMaterial.Icon.gmd_filter_list).withIdentifier(2003)
                         ),
+                        PrimaryDrawerItem().withName(R.string.drawer_item_navigation_drawer).withDescription(R.string.drawer_item_navigation_drawer_desc).withIcon(GoogleMaterial.Icon.gmd_navigation).withIdentifier(1305).withSelectable(false),
                         SectionDrawerItem().withName(R.string.drawer_item_section_header),
                         SecondaryDrawerItem().withName(R.string.drawer_item_open_source).withIcon(FontAwesome.Icon.faw_github).withIdentifier(20).withSelectable(false),
                         SecondaryDrawerItem().withName(R.string.drawer_item_contact).withIcon(GoogleMaterial.Icon.gmd_format_color_fill).withIdentifier(21).withTag("Bullhorn")
@@ -153,6 +154,7 @@ class DrawerActivity : AppCompatActivity() {
                             drawerItem.identifier == 13L -> intent = Intent(this@DrawerActivity, CollapsingToolbarActivity::class.java)
                             drawerItem.identifier == 14L -> intent = Intent(this@DrawerActivity, PersistentDrawerActivity::class.java)
                             drawerItem.identifier == 15L -> intent = Intent(this@DrawerActivity, CrossfadeDrawerLayoutActvitiy::class.java)
+                            drawerItem.identifier == 1305L -> intent = Intent(this@DrawerActivity, NavControllerActivity::class.java)
                             drawerItem.identifier == 20L -> intent = LibsBuilder()
                                     .withFields(R.string::class.java.fields)
                                     .withActivityStyle(Libs.ActivityStyle.LIGHT_DARK_TOOLBAR)

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/NavControllerActivity.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/NavControllerActivity.kt
@@ -1,0 +1,37 @@
+package com.mikepenz.materialdrawer.app
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.navigation.findNavController
+import com.mikepenz.materialdrawer.DrawerBuilder
+import com.mikepenz.materialdrawer.model.DividerDrawerItem
+import com.mikepenz.materialdrawer.model.NavigationDrawerItem
+import com.mikepenz.materialdrawer.model.PrimaryDrawerItem
+
+class NavControllerActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_nav_controller)
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+
+        val navController = findNavController(R.id.nav_host_fragment)
+
+        val drawer = DrawerBuilder()
+                .withActivity(this)
+                .withToolbar(toolbar)
+                .addDrawerItems(
+                        NavigationDrawerItem(R.id.fragmentHome, PrimaryDrawerItem().withName("Home")),
+                        DividerDrawerItem(),
+                        NavigationDrawerItem(R.id.messageFragment1, PrimaryDrawerItem().withName("Fragment1")),
+                        NavigationDrawerItem(R.id.messageFragment2, PrimaryDrawerItem().withName("Fragment2")),
+                        NavigationDrawerItem(R.id.messageFragment3, PrimaryDrawerItem().withName("Fragment3"))
+                )
+                .build()
+
+        // setup the drawer with navigation controller
+        drawer.setupWithNavController(navController)
+    }
+}

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/fragment/DemoMessageFragment.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/fragment/DemoMessageFragment.kt
@@ -1,0 +1,37 @@
+package com.mikepenz.materialdrawer.app.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.mikepenz.materialdrawer.app.R
+import kotlinx.android.synthetic.main.fragment_message_sample.*
+
+class DemoMessageFragment : Fragment() {
+
+    private var message: String? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+
+        message = arguments?.let { DemoMessageFragmentArgs.fromBundle(it).message }
+
+        return inflater.inflate(R.layout.fragment_message_sample, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        messageTextView.text = "$message"
+
+        btnFragmentHome.setOnClickListener { navigateTo(R.id.fragmentHome) }
+        btnFragment1.setOnClickListener { navigateTo(R.id.messageFragment1) }
+        btnFragment2.setOnClickListener { navigateTo(R.id.messageFragment2) }
+        btnFragment3.setOnClickListener { navigateTo(R.id.messageFragment3) }
+    }
+
+    private fun navigateTo(destination: Int) {
+        findNavController().navigate(destination)
+    }
+}

--- a/app/src/main/res/layout/activity_nav_controller.xml
+++ b/app/src/main/res/layout/activity_nav_controller.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.mikepenz.materialdrawer.app.NavControllerActivity">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+    <fragment
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/navigation" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_message_sample.xml
+++ b/app/src/main/res/layout/fragment_message_sample.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/linearLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/messageTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="8dp"
+        android:gravity="center|center_horizontal"
+        android:text="TextView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btnFragment1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:text="Go To Fragment1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnFragmentHome" />
+
+    <Button
+        android:id="@+id/btnFragmentHome"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:text="Go to Home"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/messageTextView" />
+
+    <Button
+        android:id="@+id/btnFragment2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:text="Go To Fragment2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnFragment1" />
+
+    <Button
+        android:id="@+id/btnFragment3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:text="Go To Fragment3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnFragment2" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/navigation"
+    app:startDestination="@id/fragmentHome">
+
+    <fragment
+        android:id="@+id/fragmentHome"
+        android:name="com.mikepenz.materialdrawer.app.fragment.DemoMessageFragment"
+        android:label="DemoMessageFragment"
+        tools:layout="@layout/fragment_message_sample">
+        <argument
+            android:name="message"
+            android:defaultValue="Fragment Home"
+            app:argType="string" />
+        <action
+            android:id="@+id/action_fragmentHome_to_messageFragment1"
+            app:destination="@id/messageFragment1" />
+        <action
+            android:id="@+id/action_fragmentHome_to_messageFragment2"
+            app:destination="@id/messageFragment2" />
+        <action
+            android:id="@+id/action_fragmentHome_to_messageFragment3"
+            app:destination="@id/messageFragment3" />
+    </fragment>
+    <fragment
+        android:id="@+id/messageFragment1"
+        android:name="com.mikepenz.materialdrawer.app.fragment.DemoMessageFragment"
+        android:label="DemoMessageFragment"
+        tools:layout="@layout/fragment_message_sample">
+        <argument
+            android:name="message"
+            android:defaultValue="Fragment1"
+            app:argType="string" />
+    </fragment>
+    <fragment
+        android:id="@+id/messageFragment2"
+        android:name="com.mikepenz.materialdrawer.app.fragment.DemoMessageFragment"
+        android:label="DemoMessageFragment"
+        tools:layout="@layout/fragment_message_sample">
+        <argument
+            android:name="message"
+            android:defaultValue="Fragment2"
+            app:argType="string" />
+    </fragment>
+    <fragment
+        android:id="@+id/messageFragment3"
+        android:name="com.mikepenz.materialdrawer.app.fragment.DemoMessageFragment"
+        android:label="DemoMessageFragment"
+        tools:layout="@layout/fragment_message_sample">
+        <argument
+            android:name="message"
+            android:defaultValue="Fragment3"
+            app:argType="string" />
+    </fragment>
+
+</navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="drawer_item_collapsing_toolbar_drawer_desc">Uses a CollapsingToolbarLayout</string>
     <string name="drawer_item_crossfade_drawer_layout_drawer">CrossfadeDrawerLayout</string>
     <string name="drawer_item_crossfade_drawer_layout_drawer_desc">2-Step Drawer behavior</string>
+    <string name="drawer_item_navigation_drawer">Nav Controller Drawer</string>
+    <string name="drawer_item_navigation_drawer_desc">Drawer with a Nav Controller</string>
 
     <string name="drawer_item_menu_drawer_item">Menu Drawer Item</string>
     <string name="drawer_item_menu_drawer_item_desc">Sample menu item with overflow button</string>

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,8 @@ buildscript {
                 cardview        : '1.0.0',
                 kotlin          : "1.3.41",
                 fastadapter     : "4.0.1",
-                iconics         : "4.0.1-b01"
+                iconics         : "4.0.1-b01",
+                navigation      : "2.0.0"
         ]
     }
 
@@ -37,6 +38,7 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${versions.navigation}"
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -69,6 +69,10 @@ dependencies {
 
     // kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+
+    // navigation
+    implementation "androidx.navigation:navigation-runtime:${versions.navigation}"
+    implementation "androidx.navigation:navigation-ui-ktx:${versions.navigation}"
 }
 
 apply from: '../gradle-release.gradle'

--- a/library/src/main/java/com/mikepenz/materialdrawer/Drawer.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/Drawer.kt
@@ -8,6 +8,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.widget.Toolbar
 import androidx.drawerlayout.widget.DrawerLayout
+import androidx.navigation.NavController
 import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.adapters.ModelAdapter
@@ -23,6 +24,7 @@ import com.mikepenz.materialdrawer.model.interfaces.Badgeable
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.Iconable
 import com.mikepenz.materialdrawer.model.interfaces.Nameable
+import com.mikepenz.materialdrawer.util.DrawerNavigationUI
 import com.mikepenz.materialize.Materialize
 import com.mikepenz.materialize.view.ScrimInsetsRelativeLayout
 
@@ -933,6 +935,18 @@ open class Drawer(internal val drawerBuilder: DrawerBuilder) {
             return true
         }
         return false
+    }
+
+    /**
+     * Sets up a {@link Drawer} for use with a {@link NavController}.
+     * The selected item in the Drawer will automatically be updated when the destination
+     * changes.
+     *
+     * @param navController The NavController that hosts the destination.
+     * @return
+     */
+    fun setupWithNavController(navController: NavController) {
+        DrawerNavigationUI.setupWithNavController(this, navController)
     }
 
     interface OnDrawerNavigationListener {

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/NavigationDrawerItem.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/NavigationDrawerItem.kt
@@ -1,0 +1,6 @@
+package com.mikepenz.materialdrawer.model
+
+import androidx.recyclerview.widget.RecyclerView
+import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
+
+class NavigationDrawerItem<VH : RecyclerView.ViewHolder> (val destination: Int, item: IDrawerItem<VH>) : IDrawerItem<VH> by item

--- a/library/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
@@ -1,0 +1,96 @@
+package com.mikepenz.materialdrawer.util
+
+import android.os.Bundle
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.ui.NavigationUI
+import com.mikepenz.materialdrawer.Drawer
+import com.mikepenz.materialdrawer.model.NavigationDrawerItem
+import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
+import java.lang.IllegalArgumentException
+import java.lang.ref.WeakReference
+
+/**
+ * Created by petretiandrea on 19.07.19.
+ */
+object DrawerNavigationUI {
+
+    /**
+     * Sets up a {@link Drawer} for use with a {@link NavController}. It allow to navigate
+     * to a destination when an item {@link NavigationDrawerItem} of drawer is selected.
+     * The selected item in the Drawer will automatically be updated when the destination
+     * changes.
+     *
+     * It automatically close the Drawer.
+     *
+     * @param drawer The drawer that should be kept in sync with changes to the NavController.
+     * @param navController The NavController that allow to perform the navigation actions, relying on the item selected in the Drawer
+     * @return
+     */
+    fun setupWithNavController(drawer: Drawer, navController: NavController) {
+        drawer.onDrawerItemClickListener = object : Drawer.OnDrawerItemClickListener {
+            override fun onItemClick(view: View?, position: Int, drawerItem: IDrawerItem<*>): Boolean {
+                val success = performNavigation(drawerItem, navController)
+                if(success) {
+                    drawer.closeDrawer()
+                }
+                return success
+            }
+        }
+        val weakReference: WeakReference<Drawer> = WeakReference(drawer)
+        navController.addOnDestinationChangedListener(object : NavController.OnDestinationChangedListener {
+            override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
+                val drawerWeak: Drawer? = weakReference.get()
+                if(drawerWeak == null) {
+                    navController.removeOnDestinationChangedListener(this)
+                }
+                drawerWeak?.drawerItems?.filterIsInstance<NavigationDrawerItem<*>>()?.forEach {
+                    if(matchDestination(destination, it.destination)) drawerWeak.setSelection(it, false)
+                }
+            }
+        })
+    }
+
+    /***
+     * Try to perform a navigation using the NavController to destination associated to IDrawerItem.
+     *
+     * Importantly, it assumes that the item type's is {@link NavigationDrawerItem} and that
+     * the destination matches a valid {@link NavDestination#getAction(int) action id} or {@link NavDestination#getId() destination id}
+     * to be navigated to.
+     *
+     * @param item The selected drawer item
+     * @param navController The NavController that hosts the destination.
+     * @return True if the navigation is performed, False otherwise.
+     */
+    private fun performNavigation(item: IDrawerItem<*>, navController: NavController): Boolean {
+        return when(item) {
+            is NavigationDrawerItem -> {
+                val builder = NavOptions.Builder()
+                        .setLaunchSingleTop(true)
+                        .setEnterAnim(androidx.navigation.ui.R.anim.nav_default_enter_anim)
+                        .setExitAnim(androidx.navigation.ui.R.anim.nav_default_exit_anim)
+                        .setPopEnterAnim(androidx.navigation.ui.R.anim.nav_default_pop_enter_anim)
+                        .setPopExitAnim(androidx.navigation.ui.R.anim.nav_default_pop_exit_anim)
+                val options = builder.build()
+                try {
+                    navController.navigate(item.destination, null, options)
+                    true
+                } catch (e: IllegalArgumentException) {
+                    false
+                }
+            }
+            else -> false
+        }
+    }
+
+    private fun matchDestination(destination: NavDestination, @IdRes destId: Int): Boolean {
+        var currentDestination = destination
+        while (currentDestination.id != destId && currentDestination.parent != null) {
+            currentDestination = currentDestination.parent!!
+        }
+        return currentDestination.id == destId
+    }
+}


### PR DESCRIPTION
I want to resolve #2437 in a simple way. This the result:

```kotlin
val drawer = DrawerBuilder()
                .withActivity(this)
                .withToolbar(toolbar)
                .addDrawerItems(
                        NavigationDrawerItem(R.id.fragmentHome, PrimaryDrawerItem().withName("Home")),
                        DividerDrawerItem(),
                        NavigationDrawerItem(R.id.messageFragment1, PrimaryDrawerItem().withName("Fragment1")),
                        NavigationDrawerItem(R.id.messageFragment2, PrimaryDrawerItem().withName("Fragment2")),
                        NavigationDrawerItem(R.id.messageFragment3, PrimaryDrawerItem().withName("Fragment3"))
                )
                .build()

        // setup the drawer with navigation controller
        drawer.setupWithNavController(navController)
```
I added a simple item drawer's wrapper, the `NavigationDrawerItem`. It can wrap any `IDrawerItem<VH>` by kotlin delegation, but add the field `destination` useful for NavigationController. 

The method `setupWithNavController` simply add `onDrawerItemClickListener`  to `Drawer` and a `OnDestinationChangedListener` to NavController in order to keep sync of both. See `DrawerNavigationUI`.

Finally, a test activity was added to the app module, `NavControllerActivity`.