### PR TITLE
Improve NavController support

### DIFF
--- a/app/src/main/java/com/mikepenz/materialdrawer/app/NavControllerActivity.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/NavControllerActivity.kt
@@ -27,7 +27,7 @@ class NavControllerActivity : AppCompatActivity() {
                 .withActivity(this)
                 .withToolbar(toolbar)
                 .addDrawerItems(
-                        NavigationDrawerItem(R.id.action_global_fragmentHome, PrimaryDrawerItem().withName("Home")),
+                        NavigationDrawerItem( R.id.action_global_fragmentHome, PrimaryDrawerItem().withName("Home"), null, null),
                         DividerDrawerItem(),
                         NavigationDrawerItem(R.id.messageFragment1, PrimaryDrawerItem().withName("Fragment1")),
                         NavigationDrawerItem(R.id.messageFragment2, PrimaryDrawerItem().withName("Fragment2")),
@@ -37,7 +37,5 @@ class NavControllerActivity : AppCompatActivity() {
 
         // setup the drawer with navigation controller
         drawer.setupWithNavController(navController)
-        // setup Action Bar
-        NavigationUI.setupActionBarWithNavController(this, navController, drawer.drawerLayout)
     }
 }

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/NavControllerActivity.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/NavControllerActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.navigation.findNavController
+import androidx.navigation.ui.NavigationUI
 import com.mikepenz.materialdrawer.DrawerBuilder
 import com.mikepenz.materialdrawer.model.DividerDrawerItem
 import com.mikepenz.materialdrawer.model.NavigationDrawerItem
@@ -26,7 +27,7 @@ class NavControllerActivity : AppCompatActivity() {
                 .withActivity(this)
                 .withToolbar(toolbar)
                 .addDrawerItems(
-                        NavigationDrawerItem(R.id.fragmentHome, PrimaryDrawerItem().withName("Home")),
+                        NavigationDrawerItem(R.id.action_global_fragmentHome, PrimaryDrawerItem().withName("Home")),
                         DividerDrawerItem(),
                         NavigationDrawerItem(R.id.messageFragment1, PrimaryDrawerItem().withName("Fragment1")),
                         NavigationDrawerItem(R.id.messageFragment2, PrimaryDrawerItem().withName("Fragment2")),
@@ -36,5 +37,7 @@ class NavControllerActivity : AppCompatActivity() {
 
         // setup the drawer with navigation controller
         drawer.setupWithNavController(navController)
+        // setup Action Bar
+        NavigationUI.setupActionBarWithNavController(this, navController, drawer.drawerLayout)
     }
 }

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/fragment/DemoMessageFragment.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/fragment/DemoMessageFragment.kt
@@ -29,6 +29,7 @@ class DemoMessageFragment : Fragment() {
         btnFragment1.setOnClickListener { navigateTo(R.id.messageFragment1) }
         btnFragment2.setOnClickListener { navigateTo(R.id.messageFragment2) }
         btnFragment3.setOnClickListener { navigateTo(R.id.messageFragment3) }
+        btnPopup.setOnClickListener { navigateTo(R.id.action_global_fragmentHome) }
     }
 
     private fun navigateTo(destination: Int) {

--- a/app/src/main/res/layout/fragment_message_sample.xml
+++ b/app/src/main/res/layout/fragment_message_sample.xml
@@ -78,4 +78,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/btnFragment2" />
+
+    <Button
+        android:id="@+id/btnPopup"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:text="Pop to Home"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnFragment3" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -54,5 +54,8 @@
             android:defaultValue="Fragment3"
             app:argType="string" />
     </fragment>
+    <action
+        android:id="@+id/action_global_fragmentHome"
+        app:popUpTo="@id/fragmentHome" />
 
 </navigation>

--- a/library-nav/src/main/java/com/mikepenz/materialdrawer/model/NavigationDrawerItem.kt
+++ b/library-nav/src/main/java/com/mikepenz/materialdrawer/model/NavigationDrawerItem.kt
@@ -1,8 +1,25 @@
 package com.mikepenz.materialdrawer.model
 
+import android.os.Bundle
+import androidx.navigation.NavOptions
 import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
 import com.mikepenz.materialdrawer.util.ExperimentalNavController
 
 @ExperimentalNavController
-class NavigationDrawerItem<VH : RecyclerView.ViewHolder> (val destination: Int, item: IDrawerItem<VH>) : IDrawerItem<VH> by item
+class NavigationDrawerItem<VH : RecyclerView.ViewHolder>(
+        val destination: Int,
+        item: IDrawerItem<VH>,
+        val args: Bundle? = null,
+        val options: NavOptions? = defaultOptions
+) : IDrawerItem<VH> by item {
+
+    companion object {
+        val defaultOptions = NavOptions.Builder()
+                .setLaunchSingleTop(true)
+                .setEnterAnim(androidx.navigation.ui.R.anim.nav_default_enter_anim)
+                .setExitAnim(androidx.navigation.ui.R.anim.nav_default_exit_anim)
+                .setPopEnterAnim(androidx.navigation.ui.R.anim.nav_default_pop_enter_anim)
+                .setPopExitAnim(androidx.navigation.ui.R.anim.nav_default_pop_exit_anim).build()
+    }
+}

--- a/library-nav/src/main/java/com/mikepenz/materialdrawer/model/NavigationDrawerItem.kt
+++ b/library-nav/src/main/java/com/mikepenz/materialdrawer/model/NavigationDrawerItem.kt
@@ -1,6 +1,7 @@
 package com.mikepenz.materialdrawer.model
 
 import android.os.Bundle
+import androidx.annotation.IdRes
 import androidx.navigation.NavOptions
 import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
@@ -8,7 +9,7 @@ import com.mikepenz.materialdrawer.util.ExperimentalNavController
 
 @ExperimentalNavController
 class NavigationDrawerItem<VH : RecyclerView.ViewHolder>(
-        val destination: Int,
+        @IdRes val resId: Int,
         item: IDrawerItem<VH>,
         val args: Bundle? = null,
         val options: NavOptions? = defaultOptions
@@ -20,6 +21,7 @@ class NavigationDrawerItem<VH : RecyclerView.ViewHolder>(
                 .setEnterAnim(androidx.navigation.ui.R.anim.nav_default_enter_anim)
                 .setExitAnim(androidx.navigation.ui.R.anim.nav_default_exit_anim)
                 .setPopEnterAnim(androidx.navigation.ui.R.anim.nav_default_pop_enter_anim)
-                .setPopExitAnim(androidx.navigation.ui.R.anim.nav_default_pop_exit_anim).build()
+                .setPopExitAnim(androidx.navigation.ui.R.anim.nav_default_pop_exit_anim)
+                .build()
     }
 }

--- a/library-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
+++ b/library-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
@@ -84,15 +84,8 @@ object DrawerNavigationUI {
     private fun performNavigation(item: IDrawerItem<*>, navController: NavController): Boolean {
         return when (item) {
             is NavigationDrawerItem -> {
-                val builder = NavOptions.Builder()
-                        .setLaunchSingleTop(true)
-                        .setEnterAnim(androidx.navigation.ui.R.anim.nav_default_enter_anim)
-                        .setExitAnim(androidx.navigation.ui.R.anim.nav_default_exit_anim)
-                        .setPopEnterAnim(androidx.navigation.ui.R.anim.nav_default_pop_enter_anim)
-                        .setPopExitAnim(androidx.navigation.ui.R.anim.nav_default_pop_exit_anim)
-                val options = builder.build()
                 try {
-                    navController.navigate(item.destination, null, options)
+                    navController.navigate(item.destination, item.args, item.options)
                     true
                 } catch (e: IllegalArgumentException) {
                     false

--- a/library-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
+++ b/library-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
@@ -5,7 +5,6 @@ import android.view.View
 import androidx.annotation.IdRes
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import androidx.navigation.NavOptions
 import com.mikepenz.materialdrawer.Drawer
 import com.mikepenz.materialdrawer.model.NavigationDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
@@ -64,7 +63,13 @@ object DrawerNavigationUI {
                     navController.removeOnDestinationChangedListener(this)
                 }
                 drawerWeak?.drawerItems?.filterIsInstance<NavigationDrawerItem<*>>()?.forEach {
-                    if (matchDestination(destination, it.destination)) drawerWeak.setSelection(it, false)
+                    // A ResId may refers to 3 intents.
+                    val destinationId = controller.graph.getAction(it.resId)?.let { action ->
+                        if (action.destinationId != 0) action.destinationId // an action navigate to a destination
+                        else action.navOptions?.popUpTo // an action pop to a destination
+                    } ?: it.resId // a destination
+
+                    if (matchDestination(destination, destinationId)) drawerWeak.setSelection(it, false)
                 }
             }
         })
@@ -74,7 +79,7 @@ object DrawerNavigationUI {
      * Try to perform a navigation using the NavController to destination associated to IDrawerItem.
      *
      * Importantly, it assumes that the item type's is {@link NavigationDrawerItem} and that
-     * the destination matches a valid {@link NavDestination#getAction(int) action id} or {@link NavDestination#getId() destination id}
+     * the resId matches a valid {@link NavDestination#getAction(int) action id} or {@link NavDestination#getId() destination id}
      * to be navigated to.
      *
      * @param item The selected drawer item
@@ -85,7 +90,7 @@ object DrawerNavigationUI {
         return when (item) {
             is NavigationDrawerItem -> {
                 try {
-                    navController.navigate(item.destination, item.args, item.options)
+                    navController.navigate(item.resId, item.args, item.options)
                     true
                 } catch (e: IllegalArgumentException) {
                     false


### PR DESCRIPTION
Allows user to set `NavOptions` and arguments for fragment.

Also, the following orignal NavOptions is always fail to perform "pop up" action
https://github.com/mikepenz/MaterialDrawer/blob/fe1aca9fdea4640b53422a1e9cc9f743e73422c1/library-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt#L87-L93
 it generates error message:
```
java.lang.IllegalArgumentException: Destination id == 0 can only be used in conjunction with a valid navOptions.popUpTo
```

So let user to set NavOptions (or leave it as null) is necessary.