### PR TITLE
Update material design components to 1.1.0-alpha10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
                 androidX         : '1.0.0',
                 annotation       : '1.1.0',
                 recyclerView     : '1.1.0-beta03',
-                material         : '1.1.0-alpha09',
+                material         : '1.1.0-alpha10',
                 appcompat        : '1.1.0-rc01',
                 drawerlayout     : '1.1.0-alpha03',
                 constraintLayout : '2.0.0-beta2',

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.kt
@@ -415,9 +415,9 @@ abstract class AbstractDrawerItem<T, VH : RecyclerView.ViewHolder> : IDrawerItem
      */
     protected fun getShapeAppearanceModel(ctx: Context): ShapeAppearanceModel {
         val cornerRadius = ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_item_corner_radius)
-        val shapeAppearanceModel = ShapeAppearanceModel()
-        shapeAppearanceModel.setCornerRadius(cornerRadius.toFloat())
-        return shapeAppearanceModel
+
+        return ShapeAppearanceModel()
+            .withCornerRadius(cornerRadius.toFloat())
     }
 
     /**


### PR DESCRIPTION
This updates the `com.google.android.material:material` dependency to `1.1.0-alpha10`. That version introduced a backwards-incompatible change (regarding the `ShapeAppearanceModel`), with caused apps to crash on start.