### PR TITLE
Add option to hide an item from displaying in Mini drawer.

### DIFF
--- a/app/src/main/java/com/mikepenz/materialdrawer/app/MiniDrawerActivity.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/MiniDrawerActivity.kt
@@ -104,6 +104,7 @@ class MiniDrawerActivity : AppCompatActivity() {
             customWidth = MATCH_PARENT
             itemAdapter.add(
                     PrimaryDrawerItem().withName(R.string.drawer_item_compact_header).withIcon(GoogleMaterial.Icon.gmd_brightness_5).withIdentifier(1),
+                    PrimaryDrawerItem().withName("Item NOT in mini drawer").withIcon(GoogleMaterial.Icon.gmd_bluetooth).withIdentifier(100).withIsHiddenInMiniDrawer(true),
                     PrimaryDrawerItem().withName(R.string.drawer_item_action_bar_drawer).withIcon(FontAwesome.Icon.faw_home).withBadge("22").withBadgeStyle(BadgeStyle(Color.RED, Color.RED)).withIdentifier(2).withSelectable(false),
                     PrimaryDrawerItem().withName(R.string.drawer_item_multi_drawer).withIcon(FontAwesome.Icon.faw_gamepad).withIdentifier(3),
                     PrimaryDrawerItem().withName(R.string.drawer_item_non_translucent_status_drawer).withIcon(FontAwesome.Icon.faw_eye).withIdentifier(4),

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/AbstractDrawerItem.kt
@@ -41,6 +41,9 @@ abstract class AbstractDrawerItem<T, VH : RecyclerView.ViewHolder> : IDrawerItem
     // defines if this item is selectable
     override var isSelectable = true
 
+    // defines if this item should be excluded from the mini drawer
+    override var isHiddenInMiniDrawer = false
+
     // defines if the item's background' change should be animated when it is (de)selected
     var isSelectedBackgroundAnimated = true
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/IDrawerItem.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/interfaces/IDrawerItem.kt
@@ -15,6 +15,8 @@ interface IDrawerItem<VH : RecyclerView.ViewHolder> : IItem<VH>, IItemVHFactory<
 
     override var isSelected: Boolean
 
+    var isHiddenInMiniDrawer: Boolean
+
     override val type: Int
 
     val layoutRes: Int
@@ -53,5 +55,11 @@ fun <T : IDrawerItem<*>> T.withEnabled(enabled: Boolean): T {
 @Deprecated("Please consider to replace with the actual property setter")
 fun <T : IDrawerItem<*>> T.withSelected(selected: Boolean): T {
     this.isSelected = selected
+    return this
+}
+
+@Deprecated("Please consider to replace with the actual property setter")
+fun <T : IDrawerItem<*>> T.withIsHiddenInMiniDrawer(hidden: Boolean): T {
+    this.isHiddenInMiniDrawer = hidden
     return this
 }

--- a/library/src/main/java/com/mikepenz/materialdrawer/widget/MiniDrawerSliderView.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/widget/MiniDrawerSliderView.kt
@@ -219,7 +219,10 @@ open class MiniDrawerSliderView @JvmOverloads constructor(context: Context, attr
                 }
             }
             //update everything
-            setSelection(selectedDrawerItem.identifier)
+            if (selectedDrawerItem.isHiddenInMiniDrawer)
+                selectExtension.deselect()
+            else
+                setSelection(selectedDrawerItem.identifier)
 
             false
         } else {
@@ -362,8 +365,8 @@ open class MiniDrawerSliderView @JvmOverloads constructor(context: Context, attr
      */
     open fun generateMiniDrawerItem(drawerItem: IDrawerItem<*>): IDrawerItem<*>? {
         return when (drawerItem) {
-            is SecondaryDrawerItem -> if (includeSecondaryDrawerItems) MiniDrawerItem(drawerItem).withEnableSelectedBackground(enableSelectedMiniDrawerItemBackground).withSelectedBackgroundAnimated(false) else null
-            is PrimaryDrawerItem -> MiniDrawerItem(drawerItem).withEnableSelectedBackground(enableSelectedMiniDrawerItemBackground).withSelectedBackgroundAnimated(false)
+            is SecondaryDrawerItem -> if (includeSecondaryDrawerItems && !drawerItem.isHiddenInMiniDrawer) MiniDrawerItem(drawerItem).withEnableSelectedBackground(enableSelectedMiniDrawerItemBackground).withSelectedBackgroundAnimated(false) else null
+            is PrimaryDrawerItem -> if (!drawerItem.isHiddenInMiniDrawer) MiniDrawerItem(drawerItem).withEnableSelectedBackground(enableSelectedMiniDrawerItemBackground).withSelectedBackgroundAnimated(false) else null
             is ProfileDrawerItem -> MiniProfileDrawerItem(drawerItem).apply { withEnabled(enableProfileClick) }
             else -> null
         }


### PR DESCRIPTION
This option allows to exclude a drawer item from being displayed in mini drawer, if it is used. When the excluded item is being selected using the normal drawer, the mini drawer clears the selection.