### PR TITLE
remove unneeded DrawerUtils object

### DIFF
--- a/app/src/main/java/com/mikepenz/materialdrawer/app/CustomApplication.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/CustomApplication.kt
@@ -12,7 +12,7 @@ import com.mikepenz.iconics.utils.backgroundColorRes
 import com.mikepenz.iconics.utils.sizeDp
 import com.mikepenz.materialdrawer.util.AbstractDrawerImageLoader
 import com.mikepenz.materialdrawer.util.DrawerImageLoader
-import com.mikepenz.materialdrawer.util.DrawerUtils
+import com.mikepenz.materialdrawer.util.getPlaceHolder
 
 /**
  * Created by mikepenz on 27.03.15.
@@ -51,7 +51,7 @@ class CustomApplication : MultiDexApplication() {
                 //default tags are accessible via the DrawerImageLoader.Tags
                 //custom ones can be checked via string. see the CustomUrlBasePrimaryDrawerItem LINE 111
                 return when (tag) {
-                    DrawerImageLoader.Tags.PROFILE.name -> DrawerUtils.getPlaceHolder(ctx)
+                    DrawerImageLoader.Tags.PROFILE.name -> getPlaceHolder(ctx)
                     DrawerImageLoader.Tags.ACCOUNT_HEADER.name -> IconicsDrawable(ctx, " ").apply { backgroundColorRes = R.color.primary; sizeDp = 56 }
                     "customUrlItem" -> IconicsDrawable(ctx, " ").apply { backgroundColorRes = R.color.md_red_500; sizeDp = 56 }
                     //we use the default one for

--- a/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlBasePrimaryDrawerItem.kt
+++ b/app/src/main/java/com/mikepenz/materialdrawer/app/drawerItems/CustomUrlBasePrimaryDrawerItem.kt
@@ -10,7 +10,7 @@ import com.mikepenz.materialdrawer.holder.ImageHolder
 import com.mikepenz.materialdrawer.holder.StringHolder
 import com.mikepenz.materialdrawer.model.BaseDrawerItem
 import com.mikepenz.materialdrawer.util.DrawerImageLoader
-import com.mikepenz.materialdrawer.util.DrawerUtils.setDrawerVerticalPadding
+import com.mikepenz.materialdrawer.util.setDrawerVerticalPadding
 import com.mikepenz.materialdrawer.util.themeDrawerItem
 
 /**

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileDrawerItem.kt
@@ -12,7 +12,7 @@ import com.mikepenz.materialdrawer.holder.ImageHolder
 import com.mikepenz.materialdrawer.holder.StringHolder
 import com.mikepenz.materialdrawer.model.interfaces.*
 import com.mikepenz.materialdrawer.util.DrawerImageLoader
-import com.mikepenz.materialdrawer.util.DrawerUtils.setDrawerVerticalPadding
+import com.mikepenz.materialdrawer.util.setDrawerVerticalPadding
 import com.mikepenz.materialdrawer.util.themeDrawerItem
 
 /**

--- a/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/model/ProfileSettingDrawerItem.kt
@@ -12,7 +12,7 @@ import com.mikepenz.materialdrawer.holder.BadgeStyle
 import com.mikepenz.materialdrawer.holder.ImageHolder
 import com.mikepenz.materialdrawer.holder.StringHolder
 import com.mikepenz.materialdrawer.model.interfaces.*
-import com.mikepenz.materialdrawer.util.DrawerUtils.setDrawerVerticalPadding
+import com.mikepenz.materialdrawer.util.setDrawerVerticalPadding
 import com.mikepenz.materialdrawer.util.getPrimaryDrawerIconColor
 import com.mikepenz.materialdrawer.util.getSelectableBackground
 

--- a/library/src/main/java/com/mikepenz/materialdrawer/util/AbstractDrawerImageLoader.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/util/AbstractDrawerImageLoader.kt
@@ -27,7 +27,7 @@ abstract class AbstractDrawerImageLoader : DrawerImageLoader.IDrawerImageLoader 
      * Retrieve the placeholder to display
      */
     override fun placeholder(ctx: Context): Drawable {
-        return DrawerUtils.getPlaceHolder(ctx)
+        return getPlaceHolder(ctx)
     }
 
     /**

--- a/library/src/main/java/com/mikepenz/materialdrawer/util/DrawerUtils.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/util/DrawerUtils.kt
@@ -1,3 +1,4 @@
+@file:JvmName("DrawerUtils")
 package com.mikepenz.materialdrawer.util
 
 import android.annotation.SuppressLint
@@ -25,6 +26,7 @@ import com.mikepenz.materialdrawer.widget.MaterialDrawerSliderView
 /**
  * helpful functions for working with the [MaterialDrawerSliderView]
  */
+
 
 /**
  * helper function to handle the onClick of the footer

--- a/library/src/main/java/com/mikepenz/materialdrawer/util/DrawerUtils.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/util/DrawerUtils.kt
@@ -23,326 +23,323 @@ import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
 import com.mikepenz.materialdrawer.widget.MaterialDrawerSliderView
 
 /**
- * A utils class providing helpful functions for working with the [MaterialDrawerSliderView]
+ * helpful functions for working with the [MaterialDrawerSliderView]
  */
-object DrawerUtils {
-    /**
-     * helper method to handle the onClick of the footer
-     */
-    internal fun onFooterDrawerItemClick(sliderView: MaterialDrawerSliderView, drawerItem: IDrawerItem<*>, v: View, fireOnClick: Boolean?) {
-        val checkable = drawerItem.isSelectable
-        if (checkable) {
-            sliderView.resetStickyFooterSelection()
 
-            v.isActivated = true
-            v.isSelected = true
+/**
+ * helper function to handle the onClick of the footer
+ */
+internal fun onFooterDrawerItemClick(sliderView: MaterialDrawerSliderView, drawerItem: IDrawerItem<*>, v: View, fireOnClick: Boolean?) {
+    val checkable = drawerItem.isSelectable
+    if (checkable) {
+        sliderView.resetStickyFooterSelection()
 
-            //remove the selection in the list
-            sliderView.selectExtension.deselect()
+        v.isActivated = true
+        v.isSelected = true
 
-            //find the position of the clicked footer item
-            if (sliderView.stickyFooterView != null && sliderView.stickyFooterView is LinearLayout) {
-                val footer = sliderView.stickyFooterView as LinearLayout
-                for (i in 0 until footer.childCount) {
-                    if (footer.getChildAt(i) === v) {
-                        sliderView.currentStickyFooterSelection = i
-                        break
-                    }
+        //remove the selection in the list
+        sliderView.selectExtension.deselect()
+
+        //find the position of the clicked footer item
+        if (sliderView.stickyFooterView != null && sliderView.stickyFooterView is LinearLayout) {
+            val footer = sliderView.stickyFooterView as LinearLayout
+            for (i in 0 until footer.childCount) {
+                if (footer.getChildAt(i) === v) {
+                    sliderView.currentStickyFooterSelection = i
+                    break
                 }
-            }
-        }
-
-        if (fireOnClick != null) {
-            var consumed = false
-
-            if (fireOnClick) {
-                if (drawerItem is AbstractDrawerItem<*, *> && drawerItem.onDrawerItemClickListener != null) {
-                    consumed = drawerItem.onDrawerItemClickListener?.invoke(v, drawerItem, -1)
-                            ?: false
-                }
-
-                if (sliderView.onDrawerItemClickListener != null) {
-                    consumed = sliderView.onDrawerItemClickListener?.invoke(v, drawerItem, -1)
-                            ?: false
-                }
-            }
-
-            if (!consumed) {
-                //close the drawer after click
-                sliderView.closeDrawerDelayed()
             }
         }
     }
 
-    /**
-     * helper method to handle the headerView
-     */
-    internal fun handleHeaderView(sliderView: MaterialDrawerSliderView) {
-        //use the AccountHeader if set
-        sliderView.accountHeader?.let {
-            if (sliderView.accountHeaderSticky) {
-                sliderView.stickyHeaderView = it
+    if (fireOnClick != null) {
+        var consumed = false
+
+        if (fireOnClick) {
+            if (drawerItem is AbstractDrawerItem<*, *> && drawerItem.onDrawerItemClickListener != null) {
+                consumed = drawerItem.onDrawerItemClickListener?.invoke(v, drawerItem, -1)
+                        ?: false
+            }
+
+            if (sliderView.onDrawerItemClickListener != null) {
+                consumed = sliderView.onDrawerItemClickListener?.invoke(v, drawerItem, -1)
+                        ?: false
+            }
+        }
+
+        if (!consumed) {
+            //close the drawer after click
+            sliderView.closeDrawerDelayed()
+        }
+    }
+}
+
+/**
+ * helper function to handle the headerView
+ */
+internal fun handleHeaderView(sliderView: MaterialDrawerSliderView) {
+    //use the AccountHeader if set
+    sliderView.accountHeader?.let {
+        if (sliderView.accountHeaderSticky) {
+            sliderView.stickyHeaderView = it
+        } else {
+            sliderView._headerDivider = it.dividerBelowHeader
+            sliderView._headerPadding = it.paddingBelowHeader
+            sliderView.headerView = it
+        }
+    }
+
+    //sticky header view
+    sliderView.stickyHeaderView?.let {
+        sliderView.findViewById<View>(R.id.material_drawer_sticky_header)?.let { header ->
+            sliderView.removeView(header)
+        }
+
+        //add the sticky footer view and align it to the bottom
+        val layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT)
+        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP, 1)
+        it.id = R.id.material_drawer_sticky_header
+        sliderView.addView(it, 0, layoutParams)
+
+        //now align the recyclerView below the stickyFooterView ;)
+        val layoutParamsListView = sliderView.recyclerView.layoutParams as RelativeLayout.LayoutParams
+        layoutParamsListView.addRule(RelativeLayout.BELOW, R.id.material_drawer_sticky_header)
+        sliderView.recyclerView.layoutParams = layoutParamsListView
+
+        //set a background color or the elevation will not work
+        it.background = sliderView.background
+
+        if (sliderView.stickyHeaderShadow) {
+            //add a shadow
+            if (Build.VERSION.SDK_INT >= 21) {
+                it.elevation = sliderView.context.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_header_elevation).toFloat()
             } else {
-                sliderView._headerDivider = it.dividerBelowHeader
-                sliderView._headerPadding = it.paddingBelowHeader
-                sliderView.headerView = it
+                val view = View(sliderView.context)
+                view.setBackgroundResource(R.drawable.material_drawer_shadow_bottom)
+                sliderView.addView(view, RelativeLayout.LayoutParams.MATCH_PARENT, sliderView.context.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_header_elevation))
+                //now align the shadow below the stickyHeader ;)
+                val lps = view.layoutParams as RelativeLayout.LayoutParams
+                lps.addRule(RelativeLayout.BELOW, R.id.material_drawer_sticky_header)
+                view.layoutParams = lps
             }
         }
 
-        //sticky header view
-        sliderView.stickyHeaderView?.let {
-            sliderView.findViewById<View>(R.id.material_drawer_sticky_header)?.let { header ->
-                sliderView.removeView(header)
-            }
-
-            //add the sticky footer view and align it to the bottom
-            val layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT)
-            layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP, 1)
-            it.id = R.id.material_drawer_sticky_header
-            sliderView.addView(it, 0, layoutParams)
-
-            //now align the recyclerView below the stickyFooterView ;)
-            val layoutParamsListView = sliderView.recyclerView.layoutParams as RelativeLayout.LayoutParams
-            layoutParamsListView.addRule(RelativeLayout.BELOW, R.id.material_drawer_sticky_header)
-            sliderView.recyclerView.layoutParams = layoutParamsListView
-
-            //set a background color or the elevation will not work
-            it.background = sliderView.background
-
-            if (sliderView.stickyHeaderShadow) {
-                //add a shadow
-                if (Build.VERSION.SDK_INT >= 21) {
-                    it.elevation = sliderView.context.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_header_elevation).toFloat()
-                } else {
-                    val view = View(sliderView.context)
-                    view.setBackgroundResource(R.drawable.material_drawer_shadow_bottom)
-                    sliderView.addView(view, RelativeLayout.LayoutParams.MATCH_PARENT, sliderView.context.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_header_elevation))
-                    //now align the shadow below the stickyHeader ;)
-                    val lps = view.layoutParams as RelativeLayout.LayoutParams
-                    lps.addRule(RelativeLayout.BELOW, R.id.material_drawer_sticky_header)
-                    view.layoutParams = lps
-                }
-            }
-
-            //remove the padding of the recyclerView again we have the header on top of it
-            sliderView.recyclerView.setPadding(0, 0, 0, 0)
-        }
+        //remove the padding of the recyclerView again we have the header on top of it
+        sliderView.recyclerView.setPadding(0, 0, 0, 0)
     }
+}
 
-    /**
-     * small helper to rebuild the FooterView
-     */
-    internal fun rebuildStickyFooterView(sliderView: MaterialDrawerSliderView) {
-        sliderView.stickyFooterView?.let {
-            it.removeAllViews()
-
-            //create the divider
-            if (sliderView.stickyFooterDivider) {
-                addStickyFooterDivider(it.context, it)
-            }
-
-            //fill the footer with items
-            fillStickyDrawerItemFooter(sliderView, it, View.OnClickListener { v ->
-                val drawerItem = v.getTag(R.id.material_drawer_item) as IDrawerItem<*>
-                onFooterDrawerItemClick(sliderView, drawerItem, v, true)
-            })
-
-            it.visibility = View.VISIBLE
-        } ?: run {
-            //there was no footer yet. now just create one
-            handleFooterView(sliderView, View.OnClickListener { v ->
-                val drawerItem = v.getTag(R.id.material_drawer_item) as IDrawerItem<*>
-                onFooterDrawerItemClick(sliderView, drawerItem, v, true)
-            })
-        }
-
-        sliderView.setStickyFooterSelection(sliderView.currentStickyFooterSelection, false)
-    }
-
-    /**
-     * helper method to handle the footerView
-     */
-    internal fun handleFooterView(sliderView: MaterialDrawerSliderView, onClickListener: View.OnClickListener) {
-        val ctx = sliderView.context
-
-        //use the StickyDrawerItems if set
-        if (sliderView.stickyDrawerItems.size > 0) {
-            sliderView._stickyFooterView = buildStickyDrawerItemFooter(sliderView, onClickListener)
-        }
-
-        //sticky footer view
-        sliderView.stickyFooterView?.let {
-            //add the sticky footer view and align it to the bottom
-            val layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT)
-            layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, 1)
-            it.id = R.id.material_drawer_sticky_footer
-            sliderView.addView(it, layoutParams)
-
-            /**
-            if ((sliderView.mTranslucentNavigationBar || drawer.mFullscreen) && Build.VERSION.SDK_INT >= 19) {
-            it.setPadding(0, 0, 0, UIUtils.getNavigationBarHeight(ctx))
-            }
-             **/
-
-            //now align the recyclerView above the stickyFooterView ;)
-            val layoutParamsListView = sliderView.recyclerView.layoutParams as RelativeLayout.LayoutParams
-            layoutParamsListView.addRule(RelativeLayout.ABOVE, R.id.material_drawer_sticky_footer)
-            sliderView.recyclerView.layoutParams = layoutParamsListView
-
-            //handle shadow on top of the sticky footer
-            if (sliderView.stickyFooterShadow) {
-                sliderView.stickyFooterShadowView = View(ctx).also { stickyFooterShadowView ->
-                    stickyFooterShadowView.setBackgroundResource(R.drawable.material_drawer_shadow_top)
-                    sliderView.addView(stickyFooterShadowView, RelativeLayout.LayoutParams.MATCH_PARENT, ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_footer_elevation))
-                    //now align the shadow below the stickyHeader ;)
-                    val lps = stickyFooterShadowView.layoutParams as RelativeLayout.LayoutParams
-                    lps.addRule(RelativeLayout.ABOVE, R.id.material_drawer_sticky_footer)
-                    stickyFooterShadowView.layoutParams = lps
-                }
-            }
-
-            //remove the padding of the recyclerView again we have the footer below it
-            sliderView.recyclerView.setPadding(sliderView.recyclerView.paddingLeft, sliderView.recyclerView.paddingTop, sliderView.recyclerView.paddingRight, ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_padding))
-        }
-    }
-
-
-    /**
-     * build the sticky footer item view
-     */
-    internal fun buildStickyDrawerItemFooter(sliderView: MaterialDrawerSliderView, onClickListener: View.OnClickListener): ViewGroup {
-        //create the container view
-        val linearLayout = LinearLayout(sliderView.context)
-        linearLayout.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        linearLayout.orientation = LinearLayout.VERTICAL
-        //set the background color to the drawer background color (if it has alpha the shadow won't be visible)
-        //linearLayout.background = sliderView.background
+/**
+ * small helper to rebuild the FooterView
+ */
+internal fun rebuildStickyFooterView(sliderView: MaterialDrawerSliderView) {
+    sliderView.stickyFooterView?.let {
+        it.removeAllViews()
 
         //create the divider
         if (sliderView.stickyFooterDivider) {
-            addStickyFooterDivider(sliderView.context, linearLayout)
+            addStickyFooterDivider(it.context, it)
         }
 
-        fillStickyDrawerItemFooter(sliderView, linearLayout, onClickListener)
+        //fill the footer with items
+        fillStickyDrawerItemFooter(sliderView, it, View.OnClickListener { v ->
+            val drawerItem = v.getTag(R.id.material_drawer_item) as IDrawerItem<*>
+            onFooterDrawerItemClick(sliderView, drawerItem, v, true)
+        })
 
-        return linearLayout
+        it.visibility = View.VISIBLE
+    } ?: run {
+        //there was no footer yet. now just create one
+        handleFooterView(sliderView, View.OnClickListener { v ->
+            val drawerItem = v.getTag(R.id.material_drawer_item) as IDrawerItem<*>
+            onFooterDrawerItemClick(sliderView, drawerItem, v, true)
+        })
     }
 
-    /**
-     * adds the shadow to the stickyFooter
-     *
-     * @param ctx
-     * @param footerView
-     */
-    private fun addStickyFooterDivider(ctx: Context, footerView: ViewGroup) {
-        val divider = LinearLayout(ctx)
-        val dividerParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        divider.minimumHeight = ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_footer_divider)
-        divider.orientation = LinearLayout.VERTICAL
-        divider.setBackgroundColor(ctx.getDividerColor())
-        footerView.addView(divider, dividerParams)
-    }
-
-    /**
-     * helper method to fill the sticky footer with its elements
-     */
-    internal fun fillStickyDrawerItemFooter(sliderView: MaterialDrawerSliderView, container: ViewGroup, onClickListener: View.OnClickListener) {
-        //add all drawer items
-        for (drawerItem in sliderView.stickyDrawerItems) {
-            val view = drawerItem.generateView(container.context, container)
-            view.tag = drawerItem
-
-            if (drawerItem.isEnabled) {
-                //UIUtils.setBackground(view, UIUtils.getSelectableBackground(container.getContext(), selected_color, drawerItem.isSelectedBackgroundAnimated()));
-                view.setOnClickListener(onClickListener)
-            }
-
-            container.addView(view)
-
-            //for android API 17 --> Padding not applied via xml
-            setDrawerVerticalPadding(view)
-        }
-        //and really. don't ask about this. it won't set the padding if i don't set the padding for the container
-        container.setPadding(0, 0, 0, 0)
-    }
-
-
-    /**
-     * helper to extend the layoutParams of the drawer
-     *
-     * @param params
-     * @return
-     */
-    @SuppressLint("RtlHardcoded")
-    fun processDrawerLayoutParams(drawer: MaterialDrawerSliderView, params: DrawerLayout.LayoutParams?): DrawerLayout.LayoutParams? {
-        if (params != null) {
-            val drawerLayout = drawer.drawerLayout ?: return null
-            val ctx = drawerLayout.context
-
-            val lp = drawerLayout.layoutParams as DrawerLayout.LayoutParams
-            if (lp.gravity == Gravity.RIGHT || lp.gravity == Gravity.END) {
-                params.rightMargin = 0
-                if (Build.VERSION.SDK_INT >= 17) {
-                    params.marginEnd = 0
-                }
-
-                params.leftMargin = ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_margin)
-                if (Build.VERSION.SDK_INT >= 17) {
-                    params.marginEnd = ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_margin)
-                }
-            }
-
-            val customWidth = drawer.customWidth ?: -1
-            if (customWidth > -1) {
-                params.width = customWidth
-            } else {
-                params.width = getOptimalDrawerWidth(ctx)
-            }
-        }
-
-        return params
-    }
-
-    /**
-     * helper method to get a person placeHolder drawable
-     */
-    fun getPlaceHolder(context: Context): Drawable {
-        val accountDrawable = AppCompatResources.getDrawable(context, R.drawable.material_drawer_ico_account_layer) as LayerDrawable
-        val placeholderSize = context.resources.getDimensionPixelSize(R.dimen.material_drawer_profile_icon_placeholder)
-        if (Build.VERSION.SDK_INT >= 23) {
-            accountDrawable.setLayerWidth(0, placeholderSize)
-            accountDrawable.setLayerHeight(0, placeholderSize)
-        }
-        DrawableCompat.wrap(accountDrawable.getDrawable(0)).let {
-            DrawableCompat.setTint(it, context.getThemeColor(R.attr.colorPrimary))
-            accountDrawable.setDrawableByLayerId(R.id.background, it)
-        }
-        val iconSize = context.resources.getDimensionPixelSize(R.dimen.material_drawer_profile_icon_placeholder_icon)
-        if (Build.VERSION.SDK_INT >= 23) {
-            accountDrawable.setLayerWidth(1, iconSize)
-            accountDrawable.setLayerHeight(1, iconSize)
-            accountDrawable.setLayerGravity(1, Gravity.CENTER)
-        }
-        DrawableCompat.wrap(accountDrawable.getDrawable(1)).let {
-            DrawableCompat.setTint(it, context.getThemeColor(R.attr.colorAccent))
-            accountDrawable.setDrawableByLayerId(R.id.account, it)
-        }
-        return accountDrawable
-        //IconicsDrawable(ctx, MaterialDrawerFont.Icon.mdf_person).color(IconicsColor.colorInt(ctx.getThemeColor(R.attr.colorAccent))).backgroundColor(IconicsColor.colorInt(ctx.getThemeColor(R.attr.colorPrimary))).size(IconicsSize.dp(56)).padding(IconicsSize.dp(16))
-    }
-
-
-    /**
-     * helper to set the vertical padding to the DrawerItems
-     * this is required because on API Level 17 the padding is ignored which is set via the XML
-     */
-    fun setDrawerVerticalPadding(view: View) {
-        val verticalPadding = view.context.resources.getDimensionPixelSize(R.dimen.material_drawer_vertical_padding)
-        view.setPadding(verticalPadding, 0, verticalPadding, 0)
-    }
-
+    sliderView.setStickyFooterSelection(sliderView.currentStickyFooterSelection, false)
 }
 
+/**
+ * helper function to handle the footerView
+ */
+internal fun handleFooterView(sliderView: MaterialDrawerSliderView, onClickListener: View.OnClickListener) {
+    val ctx = sliderView.context
+
+    //use the StickyDrawerItems if set
+    if (sliderView.stickyDrawerItems.size > 0) {
+        sliderView._stickyFooterView = buildStickyDrawerItemFooter(sliderView, onClickListener)
+    }
+
+    //sticky footer view
+    sliderView.stickyFooterView?.let {
+        //add the sticky footer view and align it to the bottom
+        val layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT)
+        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, 1)
+        it.id = R.id.material_drawer_sticky_footer
+        sliderView.addView(it, layoutParams)
+
+        /**
+        if ((sliderView.mTranslucentNavigationBar || drawer.mFullscreen) && Build.VERSION.SDK_INT >= 19) {
+        it.setPadding(0, 0, 0, UIUtils.getNavigationBarHeight(ctx))
+        }
+         **/
+
+        //now align the recyclerView above the stickyFooterView ;)
+        val layoutParamsListView = sliderView.recyclerView.layoutParams as RelativeLayout.LayoutParams
+        layoutParamsListView.addRule(RelativeLayout.ABOVE, R.id.material_drawer_sticky_footer)
+        sliderView.recyclerView.layoutParams = layoutParamsListView
+
+        //handle shadow on top of the sticky footer
+        if (sliderView.stickyFooterShadow) {
+            sliderView.stickyFooterShadowView = View(ctx).also { stickyFooterShadowView ->
+                stickyFooterShadowView.setBackgroundResource(R.drawable.material_drawer_shadow_top)
+                sliderView.addView(stickyFooterShadowView, RelativeLayout.LayoutParams.MATCH_PARENT, ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_footer_elevation))
+                //now align the shadow below the stickyHeader ;)
+                val lps = stickyFooterShadowView.layoutParams as RelativeLayout.LayoutParams
+                lps.addRule(RelativeLayout.ABOVE, R.id.material_drawer_sticky_footer)
+                stickyFooterShadowView.layoutParams = lps
+            }
+        }
+
+        //remove the padding of the recyclerView again we have the footer below it
+        sliderView.recyclerView.setPadding(sliderView.recyclerView.paddingLeft, sliderView.recyclerView.paddingTop, sliderView.recyclerView.paddingRight, ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_padding))
+    }
+}
+
+
+/**
+ * build the sticky footer item view
+ */
+internal fun buildStickyDrawerItemFooter(sliderView: MaterialDrawerSliderView, onClickListener: View.OnClickListener): ViewGroup {
+    //create the container view
+    val linearLayout = LinearLayout(sliderView.context)
+    linearLayout.layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    linearLayout.orientation = LinearLayout.VERTICAL
+    //set the background color to the drawer background color (if it has alpha the shadow won't be visible)
+    //linearLayout.background = sliderView.background
+
+    //create the divider
+    if (sliderView.stickyFooterDivider) {
+        addStickyFooterDivider(sliderView.context, linearLayout)
+    }
+
+    fillStickyDrawerItemFooter(sliderView, linearLayout, onClickListener)
+
+    return linearLayout
+}
+
+/**
+ * adds the shadow to the stickyFooter
+ *
+ * @param ctx
+ * @param footerView
+ */
+private fun addStickyFooterDivider(ctx: Context, footerView: ViewGroup) {
+    val divider = LinearLayout(ctx)
+    val dividerParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    divider.minimumHeight = ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_sticky_footer_divider)
+    divider.orientation = LinearLayout.VERTICAL
+    divider.setBackgroundColor(ctx.getDividerColor())
+    footerView.addView(divider, dividerParams)
+}
+
+/**
+ * helper function to fill the sticky footer with its elements
+ */
+internal fun fillStickyDrawerItemFooter(sliderView: MaterialDrawerSliderView, container: ViewGroup, onClickListener: View.OnClickListener) {
+    //add all drawer items
+    for (drawerItem in sliderView.stickyDrawerItems) {
+        val view = drawerItem.generateView(container.context, container)
+        view.tag = drawerItem
+
+        if (drawerItem.isEnabled) {
+            //UIUtils.setBackground(view, UIUtils.getSelectableBackground(container.getContext(), selected_color, drawerItem.isSelectedBackgroundAnimated()));
+            view.setOnClickListener(onClickListener)
+        }
+
+        container.addView(view)
+
+        //for android API 17 --> Padding not applied via xml
+        setDrawerVerticalPadding(view)
+    }
+    //and really. don't ask about this. it won't set the padding if i don't set the padding for the container
+    container.setPadding(0, 0, 0, 0)
+}
+
+
+/**
+ * helper to extend the layoutParams of the drawer
+ *
+ * @param params
+ * @return
+ */
+@SuppressLint("RtlHardcoded")
+fun processDrawerLayoutParams(drawer: MaterialDrawerSliderView, params: DrawerLayout.LayoutParams?): DrawerLayout.LayoutParams? {
+    if (params != null) {
+        val drawerLayout = drawer.drawerLayout ?: return null
+        val ctx = drawerLayout.context
+
+        val lp = drawerLayout.layoutParams as DrawerLayout.LayoutParams
+        if (lp.gravity == Gravity.RIGHT || lp.gravity == Gravity.END) {
+            params.rightMargin = 0
+            if (Build.VERSION.SDK_INT >= 17) {
+                params.marginEnd = 0
+            }
+
+            params.leftMargin = ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_margin)
+            if (Build.VERSION.SDK_INT >= 17) {
+                params.marginEnd = ctx.resources.getDimensionPixelSize(R.dimen.material_drawer_margin)
+            }
+        }
+
+        val customWidth = drawer.customWidth ?: -1
+        if (customWidth > -1) {
+            params.width = customWidth
+        } else {
+            params.width = getOptimalDrawerWidth(ctx)
+        }
+    }
+
+    return params
+}
+
+/**
+ * helper function to get a person placeHolder drawable
+ */
+fun getPlaceHolder(context: Context): Drawable {
+    val accountDrawable = AppCompatResources.getDrawable(context, R.drawable.material_drawer_ico_account_layer) as LayerDrawable
+    val placeholderSize = context.resources.getDimensionPixelSize(R.dimen.material_drawer_profile_icon_placeholder)
+    if (Build.VERSION.SDK_INT >= 23) {
+        accountDrawable.setLayerWidth(0, placeholderSize)
+        accountDrawable.setLayerHeight(0, placeholderSize)
+    }
+    DrawableCompat.wrap(accountDrawable.getDrawable(0)).let {
+        DrawableCompat.setTint(it, context.getThemeColor(R.attr.colorPrimary))
+        accountDrawable.setDrawableByLayerId(R.id.background, it)
+    }
+    val iconSize = context.resources.getDimensionPixelSize(R.dimen.material_drawer_profile_icon_placeholder_icon)
+    if (Build.VERSION.SDK_INT >= 23) {
+        accountDrawable.setLayerWidth(1, iconSize)
+        accountDrawable.setLayerHeight(1, iconSize)
+        accountDrawable.setLayerGravity(1, Gravity.CENTER)
+    }
+    DrawableCompat.wrap(accountDrawable.getDrawable(1)).let {
+        DrawableCompat.setTint(it, context.getThemeColor(R.attr.colorAccent))
+        accountDrawable.setDrawableByLayerId(R.id.account, it)
+    }
+    return accountDrawable
+    //IconicsDrawable(ctx, MaterialDrawerFont.Icon.mdf_person).color(IconicsColor.colorInt(ctx.getThemeColor(R.attr.colorAccent))).backgroundColor(IconicsColor.colorInt(ctx.getThemeColor(R.attr.colorPrimary))).size(IconicsSize.dp(56)).padding(IconicsSize.dp(16))
+}
+
+
+/**
+ * helper to set the vertical padding to the DrawerItems
+ * this is required because on API Level 17 the padding is ignored which is set via the XML
+ */
+fun setDrawerVerticalPadding(view: View) {
+    val verticalPadding = view.context.resources.getDimensionPixelSize(R.dimen.material_drawer_vertical_padding)
+    view.setPadding(verticalPadding, 0, verticalPadding, 0)
+}
 
 /**
  * Util method to theme the drawer item view's background (and foreground if possible)

--- a/library/src/main/java/com/mikepenz/materialdrawer/util/Extensions.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/util/Extensions.kt
@@ -34,7 +34,7 @@ fun MaterialDrawerSliderView.setStickyFooterSelection(position: Int, fireOnClick
             }
             if (footer.childCount > position && position >= 0) {
                 val drawerItem = footer.getChildAt(position).getTag(R.id.material_drawer_item) as IDrawerItem<*>
-                DrawerUtils.onFooterDrawerItemClick(this, drawerItem, footer.getChildAt(position), fireOnClick)
+                onFooterDrawerItemClick(this, drawerItem, footer.getChildAt(position), fireOnClick)
             }
         }
     }

--- a/library/src/main/java/com/mikepenz/materialdrawer/widget/MaterialDrawerSliderView.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/widget/MaterialDrawerSliderView.kt
@@ -39,13 +39,8 @@ import com.mikepenz.materialdrawer.holder.DimenHolder
 import com.mikepenz.materialdrawer.model.AbstractDrawerItem
 import com.mikepenz.materialdrawer.model.ContainerDrawerItem
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem
-import com.mikepenz.materialdrawer.util.DrawerUtils.handleFooterView
-import com.mikepenz.materialdrawer.util.DrawerUtils.handleHeaderView
-import com.mikepenz.materialdrawer.util.DrawerUtils.onFooterDrawerItemClick
-import com.mikepenz.materialdrawer.util.DrawerUtils.rebuildStickyFooterView
-import com.mikepenz.materialdrawer.util.getOptimalDrawerWidth
-import com.mikepenz.materialdrawer.util.getPosition
-import com.mikepenz.materialdrawer.util.setStickyFooterSelection
+import com.mikepenz.materialdrawer.util.*
+import com.mikepenz.materialdrawer.util.handleHeaderView
 import java.util.*
 
 /**


### PR DESCRIPTION
Seems like this was a weird conversion from Java? Using `object DrawerUtils` will create a singleton object at runtime -> remove it to create more efficient static methods instead. 