### PR TITLE
upgrade AndroidX dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,18 +16,18 @@ buildscript {
                 multiDex         : '2.0.1',
                 annotation       : '1.1.0',
                 recyclerView     : '1.1.0',
-                core             : '1.1.0',
+                core             : '1.3.0',
                 material         : '1.1.0',
                 appcompat        : '1.1.0',
-                drawerlayout     : '1.1.0-beta01',
-                constraintLayout : '2.0.0-beta5',
+                drawerlayout     : '1.1.0-rc01',
+                constraintLayout : '2.0.0-beta6',
                 cardview         : '1.0.0',
                 kotlin           : "1.3.72",
                 fastadapter      : "5.0.2",
                 iconics          : "5.0.2",
                 aboutLibs        : "8.1.2",
                 navigation       : "2.2.2",
-                slidingpaneLayout: "1.1.0-beta01"
+                slidingpaneLayout: "1.1.0-rc01"
         ]
     }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -38,6 +38,12 @@ android {
     kotlinOptions.freeCompilerArgs += ["-module-name", POM_ARTIFACT_ID]
 }
 
+project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
 dependencies {
     implementation "androidx.core:core-ktx:${versions.core}"
     implementation "androidx.drawerlayout:drawerlayout:${versions.drawerlayout}"


### PR DESCRIPTION
`core-ktx` 1.2.0+ targets Java 8 bytecode, so the library also needs to do that in order to compile.

Side note: I would appreciate it if stable releases of MaterialDrawer had only stable dependencies, it was very unexpected to find it is pulling in beta dependencies.