### PR TITLE
Support MiniDrawer in NavController setups

### DIFF
--- a/library/src/main/java/com/mikepenz/materialdrawer/widget/MaterialDrawerSliderView.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/widget/MaterialDrawerSliderView.kt
@@ -609,6 +609,11 @@ open class MaterialDrawerSliderView @JvmOverloads constructor(context: Context, 
                 consumed = item.onDrawerItemClickListener?.invoke(v, item, position) ?: false
             }
 
+            //we have to notify the miniDrawer if existing, and if the event was not consumed yet
+            if (!consumed) {
+                consumed = miniDrawer?.onItemClick(item) ?: false
+            }
+
             //call the drawer listener
             onDrawerItemClickListener?.let { mOnDrawerItemClickListener ->
                 if (delayDrawerClickEvent > 0) {
@@ -616,11 +621,6 @@ open class MaterialDrawerSliderView @JvmOverloads constructor(context: Context, 
                 } else {
                     consumed = mOnDrawerItemClickListener.invoke(v, item, position)
                 }
-            }
-
-            //we have to notify the miniDrawer if existing, and if the event was not consumed yet
-            if (!consumed) {
-                consumed = miniDrawer?.onItemClick(item) ?: false
             }
 
             //if we were a expandable item we consume the event closing makes no sense

--- a/library/src/main/java/com/mikepenz/materialdrawer/widget/MiniDrawerSliderView.kt
+++ b/library/src/main/java/com/mikepenz/materialdrawer/widget/MiniDrawerSliderView.kt
@@ -240,6 +240,7 @@ open class MiniDrawerSliderView @JvmOverloads constructor(context: Context, attr
     fun setSelection(identifier: Long) {
         if (identifier == -1L) {
             selectExtension.deselect()
+            return
         }
         val count = adapter.itemCount
         for (i in 0 until count) {


### PR DESCRIPTION
- support MiniDrawer in the navController setup by informing click events before the `onDrawerItemClickListener`
  - FIX https://github.com/mikepenz/MaterialDrawer/issues/2688
  - Note: This is a potential breaking change as it's no longer possible to consume the event from the `onDrawerItemClickListener` before informing the `miniDrawer` (which in general should be seen as an exception regardless, as it will prevent both to stay in sync)