### PR TITLE
Make ImageHolder.applyTo() use DrawerImageLoader

### DIFF
--- a/materialdrawer/src/main/java/com/mikepenz/materialdrawer/holder/ImageHolder.kt
+++ b/materialdrawer/src/main/java/com/mikepenz/materialdrawer/holder/ImageHolder.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import com.mikepenz.materialdrawer.util.DrawerImageLoader
 import com.mikepenz.materialdrawer.util.FixStateListDrawable
 import com.mikepenz.materialdrawer.util.getIconStateList
 import java.io.FileNotFoundException
@@ -59,8 +60,14 @@ open class ImageHolder {
      */
     @JvmOverloads
     open fun applyTo(imageView: ImageView, tag: String? = null): Boolean {
+        val uri = uri
         when {
-            uri != null -> imageView.setImageURI(uri)
+            uri != null -> {
+                val consumed = DrawerImageLoader.instance.setImage(imageView, uri, tag)
+                if (!consumed) {
+                    imageView.setImageURI(uri)
+                }
+            }
             icon != null -> imageView.setImageDrawable(icon)
             bitmap != null -> imageView.setImageBitmap(bitmap)
             iconRes != -1 -> imageView.setImageResource(iconRes)

--- a/materialdrawer/src/main/java/com/mikepenz/materialdrawer/view/BezelImageView.kt
+++ b/materialdrawer/src/main/java/com/mikepenz/materialdrawer/view/BezelImageView.kt
@@ -25,7 +25,6 @@ import android.annotation.TargetApi
 import android.content.Context
 import android.graphics.*
 import android.graphics.drawable.Drawable
-import android.net.Uri
 import android.os.Build
 import android.util.AttributeSet
 import android.view.MotionEvent
@@ -34,7 +33,6 @@ import android.view.ViewOutlineProvider
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.view.ViewCompat
 import com.mikepenz.materialdrawer.R
-import com.mikepenz.materialdrawer.util.DrawerImageLoader
 
 
 /**
@@ -257,27 +255,6 @@ open class BezelImageView @JvmOverloads constructor(context: Context, attrs: Att
         this.mSelectorColor = selectorColor
         this.mSelectorFilter = PorterDuffColorFilter(Color.argb(mSelectorAlpha, Color.red(mSelectorColor), Color.green(mSelectorColor), Color.blue(mSelectorColor)), PorterDuff.Mode.SRC_ATOP)
         this.invalidate()
-    }
-
-
-    override fun setImageDrawable(drawable: Drawable?) {
-        super.setImageDrawable(drawable)
-    }
-
-    override fun setImageResource(resId: Int) {
-        super.setImageResource(resId)
-    }
-
-    override fun setImageBitmap(bm: Bitmap?) {
-        super.setImageBitmap(bm)
-    }
-
-    override fun setImageURI(uri: Uri?) {
-        if ("http" == uri?.scheme || "https" == uri?.scheme) {
-            DrawerImageLoader.instance.setImage(this, uri, null)
-        } else {
-            super.setImageURI(uri)
-        }
     }
 
     fun disableTouchFeedback(disable: Boolean) {


### PR DESCRIPTION
I was trying to use `DrawerImageLoader` with a custom URI scheme for icons in `ProfileDrawerItem`. This didn't work because `ImageHolder.applyTo()` didn't have support for `DrawerImageLoader`. The view that is used to display the icon, `BezelImageView`, calls through to `DrawerImageLoader`, but only for http(s) URIs.

This PR adds `DrawerImageLoader` support to `ImageHolder.applyTo()` and removes the now unnecessary code in `BezelImageView`.

