### PR TITLE
Upgrade environment | Kotlin 1.6 | Material 1.5.0-beta01

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,15 +18,15 @@ buildscript {
                 annotation        : '1.1.0',
                 recyclerView      : '1.2.1',
                 core              : '1.7.0',
-                material          : '1.5.0-alpha05',
-                appcompat         : '1.3.1',
+                material          : '1.5.0-beta01',
+                appcompat         : '1.4.0',
                 drawerlayout      : '1.1.1',
-                constraintLayout  : '2.1.1',
+                constraintLayout  : '2.1.2',
                 cardview          : '1.0.0',
-                kotlin            : "1.5.31",
+                kotlin            : "1.6.0",
                 fastadapter       : "5.5.1",
-                iconics           : "5.3.2",
-                aboutLibs         : "10.0.0-a01",
+                iconics           : "5.3.3",
+                aboutLibs         : "10.0.0-a05",
                 navigation        : "2.3.5",
                 detekt            : '1.18.1',
                 slidingpaneLayout : "1.1.0",
@@ -41,7 +41,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0-alpha03'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${versions.navigation}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- upgrade to gradle 7.3
- update to material 1.5.0-beta01
- update to appcompat 1.4.0
- update to constraintLayout 2.1.2
- update to Kotlin 1.6.0
- update to iconics 5.3.3
- update to aboutlibs 10.0.0-a05