### PR TITLE
Kotlin 1.6.10 | Material Components 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,15 +18,15 @@ buildscript {
                 annotation        : '1.1.0',
                 recyclerView      : '1.2.1',
                 core              : '1.7.0',
-                material          : '1.5.0-beta01',
-                appcompat         : '1.4.0',
+                material          : '1.5.0',
+                appcompat         : '1.4.1',
                 drawerlayout      : '1.1.1',
-                constraintLayout  : '2.1.2',
+                constraintLayout  : '2.1.3',
                 cardview          : '1.0.0',
-                kotlin            : "1.6.0",
-                fastadapter       : "5.5.1",
+                kotlin            : "1.6.10",
+                fastadapter       : "5.6.0",
                 iconics           : "5.3.3",
-                aboutLibs         : "10.0.0-a05",
+                aboutLibs         : "10.0.0-b07",
                 navigation        : "2.3.5",
                 detekt            : '1.18.1',
                 slidingpaneLayout : "1.1.0",
@@ -41,7 +41,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${versions.navigation}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright ? 2015-2021 the original authors.
+# Copyright © 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions ?$var?, ?${var}?, ?${var:-default}?, ?${var+SET}?,
-#           ?${var#prefix}?, ?${var%suffix}?, and ?$( cmd )?;
-#         * compound commands having a testable exit status, especially ?case?;
-#         * various built-in commands including ?command?, ?set?, and ?ulimit?.
+#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
+#         * compound commands having a testable exit status, especially «case»;
+#         * various built-in commands including «command», «set», and «ulimit».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
- upgrade dependencies to stable versions
- Kotlin 1.6.10
- Material Components 1.5.0