### PR TITLE
Do not set `selectOnLongClick` on `multiSelect=false`

### DIFF
--- a/materialdrawer/src/main/java/com/mikepenz/materialdrawer/widget/MaterialDrawerSliderView.kt
+++ b/materialdrawer/src/main/java/com/mikepenz/materialdrawer/widget/MaterialDrawerSliderView.kt
@@ -250,7 +250,6 @@ open class MaterialDrawerSliderView @JvmOverloads constructor(context: Context, 
     var multiSelect
         set(value) {
             this.selectExtension.multiSelect = value
-            this.selectExtension.selectOnLongClick = !value
             this.selectExtension.allowDeselection = value
         }
         get() = this.selectExtension.multiSelect


### PR DESCRIPTION
- do not adjust `selectOnLongClick` when calling `multiSelect=false`
  - allow the direct `selectExtension` if you wish to modify the behavior
  - FIX https://github.com/mikepenz/MaterialDrawer/issues/2768