### PR TITLE
Add successListener to setupWithNavController()

### DIFF
--- a/materialdrawer-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
+++ b/materialdrawer-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
@@ -26,7 +26,7 @@ fun MaterialDrawerSliderView.setupWithNavController(
 ) {
     DrawerNavigationUI.setupWithNavController(this, navController, successListener, fallBackListener)
 }
-
+fun MaterialDrawerSliderView.justForTesting(){}
 /**
  * Created by petretiandrea on 19.07.19.
  */

--- a/materialdrawer-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
+++ b/materialdrawer-nav/src/main/java/com/mikepenz/materialdrawer/util/DrawerNavigationUI.kt
@@ -21,9 +21,10 @@ import java.lang.ref.WeakReference
  */
 fun MaterialDrawerSliderView.setupWithNavController(
         navController: NavController,
-        fallBackListener: ((v: View?, item: IDrawerItem<*>, position: Int) -> Boolean)? = null
+        successListener: ((v: View?, item: IDrawerItem<*>, position: Int) -> Boolean)? = null,
+        fallBackListener: ((v: View?, item: IDrawerItem<*>, position: Int) -> Boolean)? = null,
 ) {
-    DrawerNavigationUI.setupWithNavController(this, navController, fallBackListener)
+    DrawerNavigationUI.setupWithNavController(this, navController, successListener, fallBackListener)
 }
 
 /**
@@ -47,11 +48,13 @@ object DrawerNavigationUI {
     fun setupWithNavController(
             drawer: MaterialDrawerSliderView,
             navController: NavController,
+            successListener: ((v: View?, item: IDrawerItem<*>, position: Int) -> Boolean)? = null,
             fallBackListener: ((v: View?, item: IDrawerItem<*>, position: Int) -> Boolean)? = null
     ) {
         drawer.onDrawerItemClickListener = { v, item, position ->
             val success = performNavigation(item, navController)
             if (success) {
+                successListener?.invoke(v, item, position)
                 drawer.drawerLayout?.closeDrawer(drawer)
             } else {
                 fallBackListener?.invoke(v, item, position)


### PR DESCRIPTION
So that caller can close soft input if open. From #2772. Notice how I did not break the API, by placing the new listener before the old listener, so if anyone used the `setupWithNavController(controller) {...}` syntax, the update would not break their code.